### PR TITLE
Refactor utils

### DIFF
--- a/docs/examples/atom_mapping/atom_mapping.py
+++ b/docs/examples/atom_mapping/atom_mapping.py
@@ -39,7 +39,7 @@ def mol_align(A, B):
         A, B, transform_mode='single_undirected',
         remove_zero_col=False, remove_zero_row=False)
     # Compute the transformed molecule A
-    A = _utils._get_input_arrays(A)
+    A = _utils.setup_input_arrays(A)
     new_A = np.dot(U.T, np.dot(A, U))
     # B
     new_B = B
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 #     new_A, new_B, U, e_opt = mol_align(A, B)
 
 # the result new_A
-# A, _ = _utils._get_input_arrays(
+# A, _ = _utils.setup_input_arrays(
 #     A, B, remove_zero_col=False,
 #     remove_zero_row=False, translate=False,
 #     scale=False, check_finite=False)

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -26,7 +26,7 @@ from itertools import product
 import warnings
 
 import numpy as np
-from procrustes.utils import _get_input_arrays, eigendecomposition, error
+from procrustes.utils import _get_input_arrays, error
 
 
 def orthogonal(array_a, array_b, remove_zero_col=True,
@@ -375,7 +375,7 @@ def orthogonal_2sided(array_a, array_b, remove_zero_col=True, remove_zero_row=Tr
     mode = mode.lower()
     # Do single-transformation computation if requested
     if single_transform:
-        # check array_a and array_b are symmetric
+        # check array_a and array_b are symmetric.  #FIXME : They are no checks here.
         if mode == "approx":
             u_opt = _2sided_1trans_approx(array_a, array_b, tol)
         elif mode == "exact":
@@ -402,8 +402,8 @@ def _2sided(array_a, array_b):
 
 def _2sided_1trans_approx(array_a, array_b, tol):
     # Calculate the eigenvalue decomposition of array_a and array_b
-    _, array_ua = eigendecomposition(array_a, permute_rows=True)
-    _, array_ub = eigendecomposition(array_b, permute_rows=True)
+    _, array_ua = np.linalg.eigh(array_a)
+    _, array_ub = np.linalg.eigh(array_b)
     # compute u_umeyama
     u_umeyama = np.dot(np.abs(array_ua), np.abs(array_ub.T))
     # compute the closet unitary transformation to u_umeyama
@@ -414,9 +414,8 @@ def _2sided_1trans_approx(array_a, array_b, tol):
 
 
 def _2sided_1trans_exact(array_a, array_b):
-    _, array_ua = eigendecomposition(array_a)
-    _, array_ub = eigendecomposition(array_b)
-
+    a, array_ua = np.linalg.eigh(array_a)
+    b, array_ub = np.linalg.eigh(array_b)
     # 2^n trial-and-error test to find optimum S array
     diags = product((-1, 1.), repeat=array_a.shape[0])
 

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -26,8 +26,7 @@ from itertools import product
 import warnings
 
 import numpy as np
-from procrustes.utils import _get_input_arrays, eigendecomposition, \
-    error, singular_value_decomposition
+from procrustes.utils import _get_input_arrays, eigendecomposition, error
 
 
 def orthogonal(array_a, array_b, remove_zero_col=True,
@@ -144,7 +143,7 @@ def orthogonal(array_a, array_b, remove_zero_col=True,
                                      remove_zero_row, pad_mode, translate, scale, check_finite)
 
     # calculate SVD of array_a.T * array_b
-    array_u, _, array_vt = singular_value_decomposition(np.dot(new_a.T, new_b))
+    array_u, _, array_vt = np.linalg.svd(np.dot(new_a.T, new_b))
     # compute optimum orthogonal transformation
     array_u_opt = np.dot(array_u, array_vt)
     # compute the error

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -51,17 +51,22 @@ def orthogonal(array_a, array_b, remove_zero_col=True,
         If True, the zero rows on the top will be removed.
         Default= True.
     pad_mode : str, optional
-        Zero padding mode when the sizes of two arrays differ. Default="row-col".
-        "row": The array with fewer rows is padded with zero rows so that both have the same number
-        of rows.
-        "col": The array with fewer columns is padded with zero columns so that both have the
-        same number of columns.
-        "row-col": The array with fewer rows is padded with zero rows, and the array with fewer
-        columns is padded with zero columns, so that both have the same dimensions.
-        This does not necessarily result in square arrays.
-        "square": The arrays are padded with zero rows and zero columns so that they are both
-        squared arrays. The dimension of square array is specified based on the highest dimension,
-        i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`."
+        Specifying how to padded arrays, listed below. Default="row-col".
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin.
         Default=False.
@@ -170,17 +175,22 @@ def orthogonal_2sided(array_a, array_b, remove_zero_col=True, remove_zero_row=Tr
         If True, the zero rows on the top will be removed.
         Default= True.
     pad_mode : str, optional
-        Zero padding mode when the sizes of two arrays differ. Default="row-col".
-        "row": The array with fewer rows is padded with zero rows so that both have the same number
-        of rows.
-        "col": The array with fewer columns is padded with zero columns so that both have the
-        same number of columns.
-        "row-col": The array with fewer rows is padded with zero rows, and the array with fewer
-        columns is padded with zero columns, so that both have the same dimensions.
-        This does not necessarily result in square arrays.
-        "square": The arrays are padded with zero rows and zero columns so that they are both
-        squared arrays. The dimension of square array is specified based on the highest dimension,
-        i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`."
+        Specifying how to padded arrays, listed below. Default="row-col".
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin.
         Default=False.

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -26,7 +26,7 @@ from itertools import product
 import warnings
 
 import numpy as np
-from procrustes.utils import setup_input_arrays, error
+from procrustes.utils import error, setup_input_arrays
 
 
 def orthogonal(array_a, array_b, remove_zero_col=True,

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -26,7 +26,7 @@ from itertools import product
 import warnings
 
 import numpy as np
-from procrustes.utils import _get_input_arrays, error
+from procrustes.utils import setup_input_arrays, error
 
 
 def orthogonal(array_a, array_b, remove_zero_col=True,
@@ -139,8 +139,8 @@ def orthogonal(array_a, array_b, remove_zero_col=True,
 
     """
     # check inputs
-    new_a, new_b = _get_input_arrays(array_a, array_b, remove_zero_col,
-                                     remove_zero_row, pad_mode, translate, scale, check_finite)
+    new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col,
+                                      remove_zero_row, pad_mode, translate, scale, check_finite)
 
     # calculate SVD of array_a.T * array_b
     array_u, _, array_vt = np.linalg.svd(np.dot(new_a.T, new_b))
@@ -369,8 +369,8 @@ def orthogonal_2sided(array_a, array_b, remove_zero_col=True, remove_zero_row=Tr
         warnings.warn("The translation matrix was not well defined. \
                 Two sided rotation and translation don't commute.", stacklevel=2)
     # Check inputs
-    array_a, array_b = _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                         pad_mode, translate, scale, check_finite)
+    array_a, array_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+                                          pad_mode, translate, scale, check_finite)
     # Convert mode strings into lowercase
     mode = mode.lower()
     # Do single-transformation computation if requested

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -25,7 +25,7 @@
 import itertools as it
 
 import numpy as np
-from procrustes.utils import _get_input_arrays, error
+from procrustes.utils import setup_input_arrays, error
 from scipy.optimize import linear_sum_assignment
 
 __all__ = [
@@ -118,8 +118,8 @@ def permutation(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
 
     """
     # check inputs
-    new_a, new_b = _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                     pad_mode, translate, scale, check_finite)
+    new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+                                      pad_mode, translate, scale, check_finite)
     # compute permutation Procrustes matrix
     array_p = np.dot(new_a.T, new_b)
     array_c = np.full(array_p.shape, np.max(array_p))
@@ -350,8 +350,8 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         \end{bmatrix} \\
     """
     # check inputs
-    new_a, new_b = _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                     pad_mode, translate, scale, check_finite)
+    new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+                                      pad_mode, translate, scale, check_finite)
     # np.power() can not handle the negatives values
     # Try to convert the matrices to non-negative
     maximum = np.max(np.abs(new_b)) if np.max(np.abs(new_b)) > np.max(
@@ -732,8 +732,8 @@ def permutation_2sided_explicit(array_a, array_b,
     print("Warning: This brute-strength method is computational expensive! \n"
           "But it can be used as a checker for a small dataset.")
     # check inputs
-    new_a, new_b = _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                     pad_mode, translate, scale, check_finite)
+    new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+                                      pad_mode, translate, scale, check_finite)
     perm1 = np.zeros(np.shape(new_a))
     perm_error1 = np.inf
     for comb in it.permutations(np.arange(np.shape(new_a)[0])):

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -25,7 +25,7 @@
 import itertools as it
 
 import numpy as np
-from procrustes.utils import _get_input_arrays, eigendecomposition, error
+from procrustes.utils import _get_input_arrays, error
 from scipy.optimize import linear_sum_assignment
 
 __all__ = [
@@ -555,8 +555,8 @@ def _2sided_1trans_initial_guess_umeyama(array_a, array_b, add_noise):
         array_b += np.random.random(array_b.shape) * np.trace(np.abs(array_b)) /\
             array_b.shape[0] * 1.e-8
     # calculate the eigenvalue decomposition of A and B
-    _, array_ua = eigendecomposition(array_a)
-    _, array_ub = eigendecomposition(array_b)
+    _, array_ua = np.linalg.eigh(array_a)
+    _, array_ub = np.linalg.eigh(array_b)
     # compute U_umeyama
     array_u = np.dot(np.abs(array_ua), np.abs(array_ub.T))
     # compute closest permutation matrix to U
@@ -581,8 +581,8 @@ def _2sided_1trans_initial_guess_directed(array_a, array_b):
     a_0 = (array_a + array_a.T) * 0.5 + (array_a - array_a.T) * 0.5 * 1j
     b_0 = (array_b + array_b.T) * 0.5 + (array_b - array_b.T) * 0.5 * 1j
 
-    _, ua_0 = eigendecomposition(a_0)
-    _, ub_0 = eigendecomposition(b_0)
+    _, ua_0 = np.linalg.eigh(a_0)
+    _, ub_0 = np.linalg.eigh(b_0)
     # Compute the magnitudes of each element
     array_ua = np.sqrt(np.imag(ua_0) ** 2 + np.real(ua_0) ** 2)
     array_ub = np.sqrt(np.imag(ub_0) ** 2 + np.real(ub_0) ** 2)

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -156,17 +156,22 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
     remove_zero_row : bool, optional
         If True, the zero rows on the top will be removed. Default= True.
     pad_mode : str, optional
-        Zero padding mode when the sizes of two arrays differ. Default="row-col".
-        "row": The array with fewer rows is padded with zero rows so that both have the same number
-        of rows.
-        "col": The array with fewer columns is padded with zero columns so that both have the
-        same number of columns.
-        "row-col": The array with fewer rows is padded with zero rows, and the array with fewer
-        columns is padded with zero columns, so that both have the same dimensions.
-        This does not necessarily result in square arrays.
-        "square": The arrays are padded with zero rows and zero columns so that they are both
-        squared arrays. The dimension of square array is specified based on the highest dimension,
-        i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`."
+        Specifying how to padded arrays, listed below. Default="row-col".
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin. Default=False.
     scale : bool, optional

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -25,7 +25,7 @@
 import itertools as it
 
 import numpy as np
-from procrustes.utils import setup_input_arrays, error
+from procrustes.utils import error, setup_input_arrays
 from scipy.optimize import linear_sum_assignment
 
 __all__ = [

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -23,7 +23,7 @@
 """Rotational-Orthogonal Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import setup_input_arrays, error
+from procrustes.utils import error, setup_input_arrays
 
 
 def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -23,7 +23,7 @@
 """Rotational-Orthogonal Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import _get_input_arrays, error, singular_value_decomposition
+from procrustes.utils import _get_input_arrays, error
 
 
 def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
@@ -144,7 +144,7 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     new_a, new_b = _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
                                      pad_mode, translate, scale, check_finite)
     # compute SVD of A.T * A
-    array_u, _, array_vt = singular_value_decomposition(np.dot(new_a.T, new_b))
+    array_u, _, array_vt = np.linalg.svd(np.dot(new_a.T, new_b))
     # construct S which is an identity matrix with the smallest
     # singular value replaced by sgn(|U*V^t|).
     s_value = np.eye(new_a.shape[1])

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -47,17 +47,22 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
         If True, the zero rows on the top will be removed.
         Default= True.
     pad_mode : str, optional
-        Zero padding mode when the sizes of two arrays differ. Default="row-col".
-        "row": The array with fewer rows is padded with zero rows so that both have the same number
-        of rows.
-        "col": The array with fewer columns is padded with zero columns so that both have the
-        same number of columns.
-        "row-col": The array with fewer rows is padded with zero rows, and the array with fewer
-        columns is padded with zero columns, so that both have the same dimensions.
-        This does not necessarily result in square arrays.
-        "square": The arrays are padded with zero rows and zero columns so that they are both
-        squared arrays. The dimension of square array is specified based on the highest dimension,
-        i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`."
+        Specifying how to padded arrays, listed below. Default="row-col".
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin.
     scale : bool, optional

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -23,7 +23,7 @@
 """Rotational-Orthogonal Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import _get_input_arrays, error
+from procrustes.utils import setup_input_arrays, error
 
 
 def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
@@ -141,8 +141,8 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
 
     """
     # check inputs
-    new_a, new_b = _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                     pad_mode, translate, scale, check_finite)
+    new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+                                      pad_mode, translate, scale, check_finite)
     # compute SVD of A.T * A
     array_u, _, array_vt = np.linalg.svd(np.dot(new_a.T, new_b))
     # construct S which is an identity matrix with the smallest

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -77,17 +77,22 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
         Number of running steps after the calculation converges in the relaxation procedure.
         Default=10.
     pad_mode : str, optional
-        Zero padding mode when the sizes of two arrays differ. Default="row-col".
-        "row": The array with fewer rows is padded with zero rows so that both have the same number
-        of rows.
-        "col": The array with fewer columns is padded with zero columns so that both have the
-        same number of columns.
-        "row-col": The array with fewer rows is padded with zero rows, and the array with fewer
-        columns is padded with zero columns, so that both have the same dimensions.
-        This does not necessarily result in square arrays.
-        "square": The arrays are padded with zero rows and zero columns so that they are both
-        squared arrays. The dimension of square array is specified based on the highest dimension,
-        i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`."
+        Specifying how to padded arrays, listed below. Default="row-col".
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     remove_zero_col : bool, optional
         If True, the zero columns on the right side will be removed.
         Default=True.

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -27,7 +27,7 @@ import warnings
 
 import numpy as np
 from procrustes.permutation import permutation
-from procrustes.utils import _get_input_arrays, error
+from procrustes.utils import setup_input_arrays, error
 
 __all__ = [
     "softassign",
@@ -193,8 +193,8 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
     if beta_r <= 1:
         raise ValueError("Argument beta_r cannot be less than 1.")
 
-    array_a, array_b = _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                         pad_mode, translate, scale, check_finite)
+    array_a, array_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+                                          pad_mode, translate, scale, check_finite)
     # Initialization
     # Compute the benefit matrix
     array_c = np.kron(array_a, array_b)

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -27,7 +27,7 @@ import warnings
 
 import numpy as np
 from procrustes.permutation import permutation
-from procrustes.utils import setup_input_arrays, error
+from procrustes.utils import error, setup_input_arrays
 
 __all__ = [
     "softassign",

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -23,7 +23,7 @@
 """Symmetric Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import _get_input_arrays, error, singular_value_decomposition
+from procrustes.utils import _get_input_arrays, error
 
 
 def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
@@ -149,7 +149,7 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
                                      pad_mode, translate, scale, check_finite)
     # compute SVD of  new_a
     array_n = new_a.shape[1]
-    array_u, array_s, array_vt = singular_value_decomposition(new_a)
+    array_u, array_s, array_vt = np.linalg.svd(new_a)
 
     # add zeros to the eigenvalue array so it has length n
     if len(array_s) < new_a.shape[1]:

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -23,7 +23,7 @@
 """Symmetric Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import setup_input_arrays, error
+from procrustes.utils import error, setup_input_arrays
 
 
 def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -47,17 +47,22 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
         If True, the zero rows on the top will be removed.
         Default=True.
     pad_mode : str, optional
-        Zero padding mode when the sizes of two arrays differ. Default="row-col".
-        "row": The array with fewer rows is padded with zero rows so that both have the same number
-        of rows.
-        "col": The array with fewer columns is padded with zero columns so that both have the
-        same number of columns.
-        "row-col": The array with fewer rows is padded with zero rows, and the array with fewer
-        columns is padded with zero columns, so that both have the same dimensions.
-        This does not necessarily result in square arrays.
-        "square": The arrays are padded with zero rows and zero columns so that they are both
-        squared arrays. The dimension of square array is specified based on the highest dimension,
-        i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`."
+        Specifying how to padded arrays, listed below. Default="row-col".
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin.
         Default=False.

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -23,7 +23,7 @@
 """Symmetric Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import _get_input_arrays, error
+from procrustes.utils import setup_input_arrays, error
 
 
 def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
@@ -145,8 +145,8 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
 
     """
     # check inputs
-    new_a, new_b = _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                     pad_mode, translate, scale, check_finite)
+    new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+                                      pad_mode, translate, scale, check_finite)
     # compute SVD of  new_a
     array_n = new_a.shape[1]
     array_u, array_s, array_vt = np.linalg.svd(new_a)

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -24,7 +24,7 @@
 
 import numpy as np
 from procrustes.utils import error, hide_zero_padding, is_diagonalizable, \
-    optimal_heuristic, scale_array, translate_array, zero_padding
+    scale_array, translate_array, zero_padding
 
 
 def test_zero_padding_rows():
@@ -286,34 +286,3 @@ def test_scale_array():
     # array_trans_scale should be identical to array after the above analysis
     expected = array_a
     assert (abs(predicted - expected) < 1.e-10).all()
-
-
-def test_optimal_heuristic():
-    r"""Test optimal_heuristic with manually set up example."""
-    # test whether it works correctly
-    arr_a = np.array([[3, 6, 1, 0, 7],
-                      [4, 5, 2, 7, 6],
-                      [8, 6, 6, 1, 7],
-                      [4, 4, 7, 9, 4],
-                      [4, 8, 0, 3, 1]])
-    arr_b = np.array([[1, 8, 0, 4, 3],
-                      [6, 5, 2, 4, 7],
-                      [7, 6, 6, 8, 1],
-                      [7, 6, 1, 3, 0],
-                      [4, 4, 7, 4, 9]])
-    perm_guess = np.array([[0, 0, 1, 0, 0],
-                           [1, 0, 0, 0, 0],
-                           [0, 0, 0, 1, 0],
-                           [0, 0, 0, 0, 1],
-                           [0, 1, 0, 0, 0]])
-    perm_exact = np.array([[0, 0, 0, 1, 0],
-                           [0, 1, 0, 0, 0],
-                           [0, 0, 1, 0, 0],
-                           [0, 0, 0, 0, 1],
-                           [1, 0, 0, 0, 0]])
-    error_old = error(arr_a, arr_b, perm_guess, perm_guess)
-    perm, kopt_error = optimal_heuristic(perm_guess, arr_a, arr_b, error_old, 3)
-    np.testing.assert_equal(perm, perm_exact)
-    assert kopt_error == 0
-    # test the error exceptions
-    np.testing.assert_raises(ValueError, optimal_heuristic, perm_guess, arr_a, arr_b, error_old, 1)

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -23,16 +23,16 @@
 """Utils module for Procrustes."""
 
 import numpy as np
-from procrustes.utils import error, hide_zero_padding, scale_array, translate_array, zero_padding
+from procrustes.utils import error, _hide_zero_padding, _scale_array, _translate_array, _zero_padding
 
 
 def test_zero_padding_rows():
-    r"""Test zero_padding with random array padding rows."""
+    r"""Test _zero_padding with random array padding rows."""
     array1 = np.array([[1, 2], [3, 4]])
     array2 = np.array([[5, 6]])
 
     # match the number of rows of the 1st array
-    padded2, padded1 = zero_padding(array2, array1, pad_mode='row')
+    padded2, padded1 = _zero_padding(array2, array1, pad_mode='row')
     assert padded1.shape == (2, 2)
     assert padded2.shape == (2, 2)
     assert (abs(padded1 - array1) < 1.e-10).all()
@@ -41,7 +41,7 @@ def test_zero_padding_rows():
     # match the number of rows of the 1st array
     array3 = np.arange(8).reshape(2, 4)
     array4 = np.arange(8).reshape(4, 2)
-    padded3, padded4 = zero_padding(array3, array4, pad_mode='row')
+    padded3, padded4 = _zero_padding(array3, array4, pad_mode='row')
     assert padded3.shape == (4, 4)
     assert padded4.shape == (4, 2)
     assert (abs(array4 - padded4) < 1.e-10).all()
@@ -51,7 +51,7 @@ def test_zero_padding_rows():
     assert (abs(expected - padded3) < 1.e-10).all()
 
     # padding the padded_arrays should not change anything
-    padded5, padded6 = zero_padding(padded3, padded4, pad_mode='row')
+    padded5, padded6 = _zero_padding(padded3, padded4, pad_mode='row')
     assert padded3.shape == (4, 4)
     assert padded4.shape == (4, 2)
     assert padded5.shape == (4, 4)
@@ -61,12 +61,12 @@ def test_zero_padding_rows():
 
 
 def test_zero_padding_columns():
-    r"""Test zero_padding with random array padding columns."""
+    r"""Test _zero_padding with random array padding columns."""
     array1 = np.array([[4, 7, 2], [1, 3, 5]])
     array2 = np.array([[5], [2]])
 
     # match the number of columns of the 1st array
-    padded2, padded1 = zero_padding(array2, array1, pad_mode='col')
+    padded2, padded1 = _zero_padding(array2, array1, pad_mode='col')
     assert padded1.shape == (2, 3)
     assert padded2.shape == (2, 3)
     assert (abs(padded1 - array1) < 1.e-10).all()
@@ -75,7 +75,7 @@ def test_zero_padding_columns():
     # match the number of columns of the 1st array
     array3 = np.arange(8).reshape(8, 1)
     array4 = np.arange(8).reshape(2, 4)
-    padded3, padded4 = zero_padding(array3, array4, pad_mode='col')
+    padded3, padded4 = _zero_padding(array3, array4, pad_mode='col')
     assert padded3.shape == (8, 4)
     assert padded4.shape == (2, 4)
     assert (abs(array4 - padded4) < 1.e-10).all()
@@ -85,7 +85,7 @@ def test_zero_padding_columns():
     assert (abs(expected - padded3) < 1.e-10).all()
 
     # padding the padded_arrays should not change anything
-    padded5, padded6 = zero_padding(padded3, padded4, pad_mode='col')
+    padded5, padded6 = _zero_padding(padded3, padded4, pad_mode='col')
     assert padded3.shape == (8, 4)
     assert padded4.shape == (2, 4)
     assert padded5.shape == (8, 4)
@@ -95,11 +95,11 @@ def test_zero_padding_columns():
 
 
 def test_zero_padding_rows_columns():
-    r"""Test zero_padding with random array padding rows and columns."""
+    r"""Test _zero_padding with random array padding rows and columns."""
     array1 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
     array2 = np.array([[1, 2.5], [9, 5], [4, 8.5]])
 
-    padded2, padded1 = zero_padding(array2, array1, pad_mode='row-col')
+    padded2, padded1 = _zero_padding(array2, array1, pad_mode='row-col')
     array2_test = np.array([[1, 2.5, 0], [9, 5, 0], [4, 8.5, 0], [0, 0, 0]])
     assert padded1.shape == (4, 3)
     assert padded2.shape == (4, 3)
@@ -108,12 +108,12 @@ def test_zero_padding_rows_columns():
 
 
 def test_zero_padding_square():
-    r"""Test zero_padding with squared array."""
+    r"""Test _zero_padding with squared array."""
     # Try two equivalent (but different sized) symmetric arrays
     array1 = np.array([[60, 85, 86], [85, 151, 153], [86, 153, 158]])
     array2 = np.array([[60, 85, 86, 0, 0], [85, 151, 153, 0, 0],
                        [86, 153, 158, 0, 0], [0, 0, 0, 0, 0]])
-    square1, square2 = zero_padding(array1, array2, pad_mode='square')
+    square1, square2 = _zero_padding(array1, array2, pad_mode='square')
     assert square1.shape == square2.shape
     assert square1.shape[0] == square1.shape[1]
 
@@ -122,72 +122,72 @@ def test_zero_padding_square():
     array1 = np.dot(sym_part, sym_part.T)
     array2 = array1
     assert array1.shape == array2.shape
-    square1, square2 = zero_padding(array1, array2, pad_mode='square')
+    square1, square2 = _zero_padding(array1, array2, pad_mode='square')
     assert square1.shape == square2.shape
     assert square1.shape[0] == square1.shape[1]
     assert (abs(array2 - array1) < 1.e-10).all()
 
 
 def test_hide_zero_padding_flat():
-    r"""Test hide_zero_padding with flat array."""
+    r"""Test _hide_zero_padding with flat array."""
     array0 = np.array([0, 1, 5, 8, 0, 1])
     # check array with no padding
-    np.testing.assert_almost_equal(hide_zero_padding(array0), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array0), array0, decimal=6)
     array1 = np.array([0, 1, 5, 8, 0, 1, 0])
-    np.testing.assert_almost_equal(hide_zero_padding(array1), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array1), array0, decimal=6)
     array2 = np.array([0, 1, 5, 8, 0, 1, 0, 0, 0, 0])
-    np.testing.assert_almost_equal(hide_zero_padding(array2), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array2), array0, decimal=6)
 
 
 def test_hide_zero_padding_rectangular():
-    r"""Test hide_zero_padding by array with redundant row of zeros."""
+    r"""Test _hide_zero_padding by array with redundant row of zeros."""
     array0 = np.array([[1, 6, 0, 7, 8], [5, 7, 0, 22, 7]])
     # check array with no padding
-    np.testing.assert_almost_equal(hide_zero_padding(array0), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array0), array0, decimal=6)
     # check row-padded arrays
     array1 = np.array([[1, 6, 0, 7, 8], [5, 7, 0, 22, 7], [0, 0, 0, 0, 0]])
-    np.testing.assert_almost_equal(hide_zero_padding(array1), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array1), array0, decimal=6)
     array2 = np.array(
         [[1, 6, 0, 7, 8], [5, 7, 0, 22, 7], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]])
-    np.testing.assert_almost_equal(hide_zero_padding(array2), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array2), array0, decimal=6)
     # check column-padded arrays
     array3 = np.array([[1, 6, 0, 7, 8, 0], [5, 7, 0, 22, 7, 0]])
-    np.testing.assert_almost_equal(hide_zero_padding(array3), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array3), array0, decimal=6)
     array4 = np.array([[1, 6, 0, 7, 8, 0, 0, 0], [5, 7, 0, 22, 7, 0, 0, 0]])
-    np.testing.assert_almost_equal(hide_zero_padding(array4), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array4), array0, decimal=6)
     # check row- and column-padded arrays
     array5 = np.array([[1, 6, 0, 7, 8, 0, 0, 0],
                        [5, 7, 0, 22, 7, 0, 0, 0],
                        [0, 0, 0, 0, 0, 0, 0, 0]])
-    np.testing.assert_almost_equal(hide_zero_padding(array5), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array5), array0, decimal=6)
 
 
 def test_hide_zero_padding_square():
-    r"""Test hide_zero_padding with squared array."""
+    r"""Test _hide_zero_padding with squared array."""
     array0 = np.array([[0, 0.5, 1.0], [0, 3.1, 4.6], [0, 7.2, 9.2]])
     # check array with no padding
-    np.testing.assert_almost_equal(hide_zero_padding(array0), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array0), array0, decimal=6)
     # check row-padded arrays
     array1 = np.array(
         [[0, 0.5, 1.0], [0, 3.1, 4.6], [0, 7.2, 9.2], [0., 0., 0.]])
-    np.testing.assert_almost_equal(hide_zero_padding(array1), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array1), array0, decimal=6)
     # check column-padded arrays
     array2 = np.array([[0, 0.5, 1.0, 0], [0, 3.1, 4.6, 0], [0, 7.2, 9.2, 0]])
-    np.testing.assert_almost_equal(hide_zero_padding(array2), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array2), array0, decimal=6)
     array3 = np.array(
         [[0, 0.5, 1.0, 0, 0], [0, 3.1, 4.6, 0, 0], [0, 7.2, 9.2, 0, 0]])
-    np.testing.assert_almost_equal(hide_zero_padding(array3), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array3), array0, decimal=6)
     # check row- and column-padded arrays
     array4 = np.array([[0, 0.5, 1.0, 0, 0],
                        [0, 3.1, 4.6, 0, 0],
                        [0, 7.2, 9.2, 0, 0],
                        [0, 0.0, 0.0, 0, 0],
                        [0, 0.0, 0.0, 0, 0]])
-    np.testing.assert_almost_equal(hide_zero_padding(array4), array0, decimal=6)
+    np.testing.assert_almost_equal(_hide_zero_padding(array4), array0, decimal=6)
 
 
 def test_translate_array():
-    r"""Test translate_array with random array."""
+    r"""Test _translate_array with random array."""
     array_translated = np.array([[2, 4, 6, 10], [1, 3, 7, 0], [3, 6, 9, 4]])
     # Find the means over each dimension
     column_means_translated = np.zeros(4)
@@ -196,7 +196,7 @@ def test_translate_array():
     # Confirm that these means are not all zero
     assert (abs(column_means_translated) > 1.e-8).all()
     # Compute the origin-centred array
-    origin_centred_array, _ = translate_array(array_translated)
+    origin_centred_array, _ = _translate_array(array_translated)
     # Confirm that the column means of the origin-centred array are all zero
     column_means_centred = np.ones(4)
     for i in range(4):
@@ -206,7 +206,7 @@ def test_translate_array():
     # translating a centered array does not do anything
     centred_sphere = 25.25 * np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1],
                                        [-1, 0, 0], [0, -1, 0], [0, 0, -1]])
-    predicted, _ = translate_array(centred_sphere)
+    predicted, _ = _translate_array(centred_sphere)
     expected = centred_sphere
     assert (abs(predicted - expected) < 1.e-8).all()
 
@@ -215,7 +215,7 @@ def test_translate_array():
         [[1, 4, 5], [1, 4, 5], [1, 4, 5], [1, 4, 5], [1, 4, 5], [1, 4, 5]])
     translated_sphere = np.array(
         [[1, 0, 0], [0, 1, 0], [0, 0, 1], [-1, 0, 0], [0, -1, 0], [0, 0, -1]]) + shift
-    predicted, _ = translate_array(translated_sphere)
+    predicted, _ = _translate_array(translated_sphere)
     expected = np.array(
         [[1, 0, 0], [0, 1, 0], [0, 0, 1], [-1, 0, 0], [0, -1, 0], [0, 0, -1]])
     assert (abs(predicted - expected) < 1.e-8).all()
@@ -228,27 +228,27 @@ def test_translate_array():
     # Define the translated original array
     array_translated = array_a + translate
     # Begin translation analysis
-    centroid_a_to_b, _ = translate_array(array_a, array_translated)
+    centroid_a_to_b, _ = _translate_array(array_a, array_translated)
     assert (abs(centroid_a_to_b - array_translated) < 1.e-10).all()
 
 
 def test_scale_array():
-    r"""Test scale_array with random array."""
+    r"""Test _scale_array with random array."""
     # Rescale arbitrary array
     array_a = np.array([[6, 2, 1], [5, 2, 9], [8, 6, 4]])
     # Confirm Frobenius normaliation has transformed the array to lie on the unit sphere in
     # the R^(mxn) vector space. We must centre the array about the origin before proceeding
-    array_a, _ = translate_array(array_a)
+    array_a, _ = _translate_array(array_a)
     # Confirm proper centering
     column_means_centred = np.zeros(3)
     for i in range(3):
         column_means_centred[i] = np.mean(array_a[:, i])
     assert (abs(column_means_centred) < 1.e-10).all()
     # Proceed with Frobenius normalization
-    scaled_array, _ = scale_array(array_a)
+    scaled_array, _ = _scale_array(array_a)
     # Confirm array has unit norm
     assert abs(np.sqrt((scaled_array ** 2.).sum()) - 1.) < 1.e-10
-    # This test verifies that when scale_array is applied to two scaled unit spheres,
+    # This test verifies that when _scale_array is applied to two scaled unit spheres,
     # the Frobenius norm of each new sphere is unity.
     # Rescale spheres to unitary scale
     # Define arbitrarily scaled unit spheres
@@ -257,8 +257,8 @@ def test_scale_array():
     sphere_1 = 230.15 * unit_sphere
     sphere_2 = .06 * unit_sphere
     # Proceed with scaling procedure
-    scaled1, _ = scale_array(sphere_1)
-    scaled2, _ = scale_array(sphere_2)
+    scaled1, _ = _scale_array(sphere_1)
+    scaled2, _ = _scale_array(sphere_2)
     # Confirm each scaled array has unit Frobenius norm
     assert abs(np.sqrt((scaled1 ** 2.).sum()) - 1.) < 1.e-10
     assert abs(np.sqrt((scaled2 ** 2.).sum()) - 1.) < 1.e-10
@@ -272,7 +272,7 @@ def test_scale_array():
     # Define the scaled original array
     array_scaled = scale * array_a
     # Begin scaling analysis
-    scaled_a, _ = scale_array(array_a, array_scaled)
+    scaled_a, _ = _scale_array(array_a, array_scaled)
     assert (abs(scaled_a - array_scaled) < 1.e-10).all()
 
     # Define an arbitrary array
@@ -281,7 +281,7 @@ def test_scale_array():
     array_scale = 123.45 * array_a
     # Verify the validity of the translate_scale analysis
     # Proceed with analysis, matching array_trans_scale to array
-    predicted, _ = scale_array(array_scale, array_a)
+    predicted, _ = _scale_array(array_scale, array_a)
     # array_trans_scale should be identical to array after the above analysis
     expected = array_a
     assert (abs(predicted - expected) < 1.e-10).all()

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -23,8 +23,7 @@
 """Utils module for Procrustes."""
 
 import numpy as np
-from procrustes.utils import error, hide_zero_padding, is_diagonalizable, \
-    scale_array, translate_array, zero_padding
+from procrustes.utils import error, hide_zero_padding, scale_array, translate_array, zero_padding
 
 
 def test_zero_padding_rows():

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -23,7 +23,7 @@
 """Utils module for Procrustes."""
 
 import numpy as np
-from procrustes.utils import error, _hide_zero_padding, _scale_array, _translate_array, _zero_padding
+from procrustes.utils import _hide_zero_padding, _scale_array, _translate_array, _zero_padding
 
 
 def test_zero_padding_rows():

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -117,6 +117,14 @@ def test_zero_padding_square():
     assert square1.shape == square2.shape
     assert square1.shape[0] == square1.shape[1]
 
+    # Test in the scenario they have the same shape but rectangular.
+    array1 = np.array([[60, 85, 86, 1.], [85, 151, 153, 2.], [86, 153, 158, 10.]])
+    array2 = np.array([[60, 85, 86, 1.], [85, 151, 153, 2.], [86, 153, 158, 10.]])
+    square1, square2 = _zero_padding(array1, array2, pad_mode='square')
+    assert square1.shape == square2.shape
+    assert square1.shape[0] == square1.shape[1]
+    assert square1.shape[0] == 4
+
     # Performing the analysis on equally sized square arrays should return the same input arrays
     sym_part = np.array([[1, 7, 8, 4], [6, 4, 8, 1]])
     array1 = np.dot(sym_part, sym_part.T)

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -23,7 +23,7 @@
 """Utils module for Procrustes."""
 
 import numpy as np
-from procrustes.utils import eigendecomposition, error, hide_zero_padding, is_diagonalizable, \
+from procrustes.utils import error, hide_zero_padding, is_diagonalizable, \
     optimal_heuristic, scale_array, translate_array, zero_padding
 
 
@@ -286,30 +286,6 @@ def test_scale_array():
     # array_trans_scale should be identical to array after the above analysis
     expected = array_a
     assert (abs(predicted - expected) < 1.e-10).all()
-
-
-def test_eigenvalue_decomposition():
-    r"""Test eigenvaluedecomposition with random array."""
-    array_a = np.array([[-1. / 2, 3. / 2], [3. / 2, -1. / 2]])
-    assert is_diagonalizable(array_a) is True
-    s_predicted, u_predicted = eigendecomposition(array_a)
-    s_expected = np.array([1, -2])
-    assert (abs(np.dot(u_predicted, u_predicted.T) - np.eye(2)) < 1.e-8).all()
-    # The eigenvalue decomposition must return the original array
-    predicted = np.dot(u_predicted, np.dot(np.diag(s_predicted), u_predicted.T))
-    assert (abs(predicted - array_a) < 1.e-8).all()
-    assert (abs(s_predicted - s_expected) < 1.e-8).all()
-    # check that product of u, s, and u.T obtained from eigenvalue_decomposition gives
-    # an original array
-    array_a = np.array([[3, 1], [1, 3]])
-    assert is_diagonalizable(array_a) is True
-    s_predicted, u_predicted = eigendecomposition(array_a)
-    s_expected = np.array([4, 2])
-    assert (abs(np.dot(u_predicted, u_predicted.T) - np.eye(2)) < 1.e-8).all()
-    # The eigenvalue decomposition must return the original array
-    predicted = np.dot(u_predicted, np.dot(np.diag(s_predicted), u_predicted.T))
-    assert (abs(predicted - array_a) < 1.e-8).all()
-    assert (abs(s_predicted - s_expected) < 1.e-8).all()
 
 
 def test_optimal_heuristic():

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -80,7 +80,7 @@ def _zero_padding(array_a, array_b, pad_mode="row-col"):
     if array_a.ndim != 2 or array_b.ndim != 2:
         raise ValueError("Arguments array_a & array_b should be 2D arrays.")
 
-    if array_a.shape == array_b.shape:
+    if array_a.shape == array_b.shape and array_a.shape[0] == array_a.shape[1]:
         # special case of square arrays, mode is set to None so that array_a & array_b are returned.
         pad_mode = None
 

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -224,37 +224,6 @@ def hide_zero_padding(array_a, remove_zero_col=True, remove_zero_row=True, tol=1
     return array_a
 
 
-def is_diagonalizable(array_a):
-    """
-    Check whether the given array is diagonalizable.
-
-    Parameters
-    ----------
-    array_a: ndarray
-        A square array for which the diagonalizability is checked.
-
-    Returns
-    -------
-    diagonalizable : bool
-        True if the array is diagonalizable, otherwise False.
-
-    """
-    # check array is square
-    array_a = hide_zero_padding(array_a)
-    if array_a.shape[0] != array_a.shape[1]:
-        raise ValueError("Argument array should be a square array! shape={0}".format(array_a.shape))
-    # SVD decomposition of array
-    array_u, _, _ = np.linalg.svd(array_a)
-    rank_u = np.linalg.matrix_rank(array_u)
-    rank_a = np.linalg.matrix_rank(array_a)
-    diagonalizable = True
-    # If the ranks of u and a are not equal, the eigenvectors cannot span the dimension
-    # of the vector space, and the array cannot be diagonalized.
-    if rank_u != rank_a:
-        diagonalizable = False
-    return diagonalizable
-
-
 def error(array_a, array_b, array_u, array_v=None):
     r"""
     Return the single- or double- sided Procrustes error.

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -25,19 +25,15 @@ Utility Module.
 
 Functions
 ---------
-zero_padding :
-translate_array :
-scale_array :
-hide_zero_padding :
-is_diagonalizable :
-optimal_heuristic :
+error :
+setup_input_arrays :
 
 """
 
 import numpy as np
 
 
-def zero_padding(array_a, array_b, pad_mode="row-col"):
+def _zero_padding(array_a, array_b, pad_mode="row-col"):
     r"""
     Return arrays padded with rows and/or columns of zero.
 
@@ -117,7 +113,7 @@ def zero_padding(array_a, array_b, pad_mode="row-col"):
     return array_a, array_b
 
 
-def translate_array(array_a, array_b=None):
+def _translate_array(array_a, array_b=None):
     """
     Return translated array_a and translation vector.
 
@@ -147,7 +143,7 @@ def translate_array(array_a, array_b=None):
     return array_a - centroid, -centroid
 
 
-def scale_array(array_a, array_b=None):
+def _scale_array(array_a, array_b=None):
     """
     Return scaled array_a and scaling vector.
 
@@ -177,7 +173,7 @@ def scale_array(array_a, array_b=None):
     return array_a * scale, scale
 
 
-def hide_zero_padding(array_a, remove_zero_col=True, remove_zero_row=True, tol=1.0e-8):
+def _hide_zero_padding(array_a, remove_zero_col=True, remove_zero_row=True, tol=1.0e-8):
     r"""
     Return array with zero-padded rows (bottom) and columns (right) removed.
 
@@ -272,15 +268,15 @@ def setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
     if check_finite:
         array_a = np.asarray_chkfinite(array_a)
         array_b = np.asarray_chkfinite(array_b)
-    array_a = hide_zero_padding(array_a, remove_zero_col, remove_zero_row)
-    array_b = hide_zero_padding(array_b, remove_zero_col, remove_zero_row)
+    array_a = _hide_zero_padding(array_a, remove_zero_col, remove_zero_row)
+    array_b = _hide_zero_padding(array_b, remove_zero_col, remove_zero_row)
     if translate:
-        array_a, _ = translate_array(array_a)
-        array_b, _ = translate_array(array_b)
+        array_a, _ = _translate_array(array_a)
+        array_b, _ = _translate_array(array_b)
     if scale:
-        array_a, _ = scale_array(array_a)
-        array_b, _ = scale_array(array_b)
-    return zero_padding(array_a, array_b, pad_mode)
+        array_a, _ = _scale_array(array_a)
+        array_b, _ = _scale_array(array_b)
+    return _zero_padding(array_a, array_b, pad_mode)
 
 
 def _check_arraytypes(*args):

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -34,9 +34,6 @@ optimal_heuristic :
 
 """
 
-import copy
-import itertools as it
-
 import numpy as np
 
 
@@ -51,21 +48,22 @@ def zero_padding(array_a, array_b, pad_mode="row-col"):
     array_b : ndarray
         The 2d-array :math:`\mathbf{B}_{n_b \times m_b}`.
     pad_mode : str
-        Specifying how to padded arrays. Options:
-        **"row"**
-        The array with fewer rows is padded with zero rows so that both have the same
-        number of rows.
-        **"col"**
-        The array with fewer columns is padded with zero columns so that both have the
-        same number of columns.
-        **"row-col"**
-        The array with fewer rows is padded with zero rows, and the array with fewer
-        columns is padded with zero columns, so that both have the same dimensions.
-        This does not necessarily result in square arrays.
-        "square"
-        The arrays are padded with zero rows and zero columns so that they are both
-        squared arrays. The dimension of square array is specified based on the highest
-        dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
+        Specifying how to padded arrays. Should be one of
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
 
     Returns
     -------
@@ -73,6 +71,7 @@ def zero_padding(array_a, array_b, pad_mode="row-col"):
         Padded array_a.
     padded_b : ndarray
         Padded array_b.
+
     """
     # sanity checks
     if not isinstance(array_a, np.ndarray) or not isinstance(array_b, np.ndarray):
@@ -131,12 +130,13 @@ def translate_array(array_a, array_b=None):
 
     Returns
     -------
-    array_a, ndarray
+    array_a : ndarray
         If array_b is None, array_a is translated to origin using its centroid.
         If array_b is given, array_a is translated to centroid of array_b (the centroid of
         translated array_a will centroid with the centroid array_b).
     centroid : float
         If array_b is given, the centroid is returned.
+
     """
     # The mean is strongly affected by outliers and is not a robust estimator for central location
     # see https://docs.python.org/3.6/library/statistics.html?highlight=mean#statistics.mean
@@ -167,6 +167,7 @@ def scale_array(array_a, array_b=None):
         will be equal norm of array_b).
     scale : float
         The scaling factor to match array_b norm.
+
     """
     # scaling factor to match unit sphere
     scale = 1. / np.linalg.norm(array_a)
@@ -236,6 +237,7 @@ def is_diagonalizable(array_a):
     -------
     diagonalizable : bool
         True if the array is diagonalizable, otherwise False.
+
     """
     # check array is square
     array_a = hide_zero_padding(array_a)

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -164,37 +164,6 @@ def scale_array(array_a, array_b=None):
     return array_a * scale, scale
 
 
-def eigendecomposition(array_a, permute_rows=False):
-    r"""
-    Compute the eigenvalue decomposition of an array.
-
-    .. math::
-      \mathbf{A} = \mathbf{U} \mathbf{S} \mathbf{U}^\dagger
-
-    Parameters
-    ----------
-    array_a: ndarray
-       The 2D array to decompose.
-    permute_rows : bool, default = False
-        If True, permute rows of eigenvectors according to the greatest to least eigenvalues.
-        Otherwise, permute columns.
-
-    Returns
-    -------
-    array_s : ndarray
-        The 1D array of the eigenvalues, sorted from greatest to least.
-    array_v : ndarray
-        The 2D array of eigen vectors, sorted according to greatest to least eigenvalues.
-
-    """
-    # find eigenvalues & eigenvectors
-    array_s, array_v = np.linalg.eigh(array_a)
-    # get index of sorted eigenvalues from largest to smallest
-    idx = array_s.argsort()[::-1]
-    # Return permuted eigenvalues & eigenvectors
-    return array_s[idx], array_v[idx] if permute_rows else array_v[:, idx]
-
-
 def hide_zero_padding(array_a, remove_zero_col=True, remove_zero_row=True, tol=1.0e-8):
     r"""
     Return array with zero-padded rows (bottom) and columns (right) removed.

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -164,30 +164,6 @@ def scale_array(array_a, array_b=None):
     return array_a * scale, scale
 
 
-def singular_value_decomposition(array_a):
-    r"""
-    Return singular value decomposition (SVD) factorization of an array.
-
-    .. math::
-      \mathbf{A} = \mathbf{U} \mathbf{\Sigma} \mathbf{V}^\dagger
-
-    Parameters
-    ----------
-    array_a: ndarray
-        The 2d-array :math:`\mathbf{A}_{m \times n}` to factorize.
-
-    Returns
-    -------
-    array_u : ndarray
-        Unitary matrix :math:`\mathbf{U}_{m \times m}`.
-    array_s : ndarray
-        The singular values of matrix sorted in descending order.
-    array_v : ndarray
-        Unitary matrix :math:`\mathbf{V}_{n \times n}`.
-    """
-    return np.linalg.svd(array_a)
-
-
 def eigendecomposition(array_a, permute_rows=False):
     r"""
     Compute the eigenvalue decomposition of an array.
@@ -285,7 +261,7 @@ def is_diagonalizable(array_a):
     if array_a.shape[0] != array_a.shape[1]:
         raise ValueError("Argument array should be a square array! shape={0}".format(array_a.shape))
     # SVD decomposition of array
-    array_u, _, _ = singular_value_decomposition(array_a)
+    array_u, _, _ = np.linalg.svd(array_a)
     rank_u = np.linalg.matrix_rank(array_u)
     rank_a = np.linalg.matrix_rank(array_a)
     diagonalizable = True

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -318,11 +318,3 @@ def _check_arraytypes(*args):
         raise TypeError("Matrix inputs must be NumPy arrays")
     if any(x.ndim != 2 for x in args):
         raise TypeError("Matrix inputs must be 2-dimensional arrays")
-
-
-def _check_rank(array_a):
-    r"""Check whether the given array is diagonalizable."""
-    array_a = hide_zero_padding(array_a)
-    array_u, _, _ = np.linalg.svd(array_a)
-    if np.linalg.matrix_rank(array_u) != np.linalg.matrix_rank(array_a):
-        raise np.linalg.LinAlgError("Matrix cannot be diagonalized")

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -294,8 +294,8 @@ def error(array_a, array_b, array_u, array_v=None):
     return np.trace(np.dot(array_e.T, array_e))
 
 
-def _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                      pad_mode, translate, scale, check_finite):
+def setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+                       pad_mode, translate, scale, check_finite):
     r"""Check and process array inputs to Procrustes transformation routines."""
     _check_arraytypes(array_a, array_b)
     if check_finite:

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -20,7 +20,19 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
-"""Utility Module."""
+"""
+Utility Module.
+
+Functions
+---------
+zero_padding :
+translate_array :
+scale_array :
+hide_zero_padding :
+is_diagonalizable :
+optimal_heuristic :
+
+"""
 
 import copy
 import itertools as it
@@ -280,52 +292,6 @@ def error(array_a, array_b, array_u, array_v=None):
         else np.dot(np.dot(array_u.T, array_a), array_v)
     array_e -= array_b
     return np.trace(np.dot(array_e.T, array_e))
-
-
-def optimal_heuristic(perm, array_a, array_b, ref_error, k_opt=3):
-    r"""
-    K-opt heuristic to improve the accuracy.
-
-    Perform k-opt local search with every possible valid combination of the swapping mechanism.
-
-    Parameters
-    ----------
-    perm : np.ndarray
-        The permutation array which remains to be processed with k-opt local search.
-    array_a : np.ndarray
-        The array to be permuted.
-    array_b : np.ndarray
-        The reference array.
-    ref_error : float
-        The reference error value.
-    k_opt : int, optional
-        Order of local search. Default=3.
-
-    Returns
-    -------
-    perm : np.ndarray
-        The permutation array after optimal heuristic search.
-    kopt_error : float
-        The error distance of two arrays with the updated permutation array.
-
-    """
-    if k_opt < 2:
-        raise ValueError("K_opt value must be a integer greater than 2.")
-    num_row = perm.shape[0]
-    kopt_error = ref_error
-    # all the possible row-wise permutations
-    for comb in it.combinations(np.arange(num_row), r=k_opt):
-        for comb_perm in it.permutations(comb, r=k_opt):
-            if comb_perm != comb:
-                perm_kopt = copy.deepcopy(perm)
-                perm_kopt[comb, :] = perm_kopt[comb_perm, :]
-                e_kopt_new = error(array_a, array_b, perm_kopt, perm_kopt)
-                if e_kopt_new < kopt_error:
-                    perm = perm_kopt
-                    kopt_error = e_kopt_new
-                    if kopt_error == 0:
-                        break
-    return perm, kopt_error
 
 
 def _get_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,


### PR DESCRIPTION
This pull request is only concerned with utils.py and test_utils.py.

Removed
-------------
The following functions and their tests were removed since they weren't used anywhere.
- is_diagonalizable (25824ae) 
- optimal_heuristic (16b0539) 
- check_rank. (6b7f1d0)

The following were removed, since they were one-liners/wrappers over the numpy counterpart.
- eigendecomposition (8e5c058 , b6021fa )
- singular_value_decomposition (6011c6f , 2b76734 )

Other
--------
Fixed documentation for the padding argument. (23b25b4  )
Changed functions that weren't used outside of utils.py to private. (54ffd44)
Added documentation to setup_input_arrays, since it is used in all Procruste's methods (5b874c7 ).
Fixed bug in _zero_padding, where rectangular matrices of the same shape aren't converted to square (f0d350a, c7d0f18). 


