### PR TITLE
Fix linter w0632

### DIFF
--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -424,8 +424,8 @@ def _2sided_1trans_approx(array_a, array_b, tol):
 
 
 def _2sided_1trans_exact(array_a, array_b):
-    a, array_ua = np.linalg.eigh(array_a)
-    b, array_ub = np.linalg.eigh(array_b)
+    _, array_ua = np.linalg.eigh(array_a)
+    _, array_ub = np.linalg.eigh(array_b)
     # 2^n trial-and-error test to find optimum S array
     diags = product((-1, 1.), repeat=array_a.shape[0])
 

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -266,14 +266,6 @@ def test_two_sided_orthogonal_rotate_reflect_pad():
     r"""Test 2sided orthogonal by 3by3 array with rotation, reflection and zero padding."""
     # define an arbitrary array
     array_a = np.array([[1., 4.], [6., 7]])
-    # rotation by 30 degrees
-    theta = np.pi / 6
-    rot1 = np.array([[np.cos(theta), -np.sin(theta)],
-                     [np.sin(theta), np.cos(theta)]])
-    array_b = np.dot(array_a, rot1)
-    # reflection 1 in x-axis
-    ref1 = np.array([[1, 0], [0, -1]])
-    array_b = np.dot(ref1, array_b)
     # rotation by -45 degrees
     theta = -np.pi / 4
     rot2 = np.array([[np.cos(theta), -np.sin(theta)],

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -408,9 +408,8 @@ def test_two_sided_orthogonal_single_transformation_scale_3by3():
     assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
     assert_almost_equal(result[3], 0, decimal=8)
     # check transformation array and error of "approx" mode
-    _, _, array_u, e_opt = orthogonal_2sided(
-        array_a, array_b, translate=True,
-        scale=True, single_transform=True, mode="approx")
+    result = orthogonal_2sided(array_a, array_b, translate=True, scale=True,
+                               single_transform=True, mode="approx")
     assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
     assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
     # error: 2.1162061737807796

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -233,15 +233,13 @@ def test_two_sided_orthogonal_identical():
     # case of identical square arrays
     array_a = np.arange(16).reshape(4, 4)
     array_b = np.copy(array_a)
-    _, _, array_u1, array_u2, e_opt = orthogonal_2sided(
-        array_a, array_b, single_transform=False)
-
+    result = orthogonal_2sided(array_a, array_b, single_transform=False)
     # check transformation array is identity
-    assert_almost_equal(np.linalg.det(array_u1), 1.0, decimal=6)
-    assert_almost_equal(np.linalg.det(array_u2), 1.0, decimal=6)
-    assert_almost_equal(array_u1, np.eye(4), decimal=6)
-    assert_almost_equal(array_u2, np.eye(4), decimal=6)
-    assert_almost_equal(e_opt, 0., decimal=6)
+    assert_almost_equal(np.linalg.det(result[2]), 1.0, decimal=6)
+    assert_almost_equal(np.linalg.det(result[3]), 1.0, decimal=6)
+    assert_almost_equal(result[2], np.eye(4), decimal=6)
+    assert_almost_equal(result[3], np.eye(4), decimal=6)
+    assert_almost_equal(result[4], 0., decimal=6)
 
 
 def test_two_sided_orthogonal_rotate_reflect():
@@ -254,15 +252,14 @@ def test_two_sided_orthogonal_rotate_reflect():
     # define array_b by transforming array_a
     array_b = np.dot(np.dot(ref, array_a), rot)
     # compute procrustes transformation
-    _, _, array_u1, array_u2, e_opt = orthogonal_2sided(
-        array_a, array_b, translate=True, scale=True, single_transform=False)
+    result = orthogonal_2sided(array_a, array_b, translate=True, scale=True, single_transform=False)
     # check transformation array orthogonality
-    assert_almost_equal(np.dot(array_u1, array_u1.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.dot(array_u2, array_u2.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u1), 1.0, decimal=6)
-    assert_almost_equal(np.linalg.det(array_u2), 1.0, decimal=6)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.dot(result[3], result[3].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.linalg.det(result[2]), 1.0, decimal=6)
+    assert_almost_equal(np.linalg.det(result[3]), 1.0, decimal=6)
     # transformation should return zero error
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(result[4], 0, decimal=6)
 
 
 def test_two_sided_orthogonal_rotate_reflect_pad():
@@ -286,17 +283,13 @@ def test_two_sided_orthogonal_rotate_reflect_pad():
     array_b = np.concatenate((array_b, np.zeros((2, 6))), axis=0)
 
     # compute Procrustes transformation
-    _, _, array_u1, array_u2, e_opt = orthogonal_2sided(
-        array_a, array_b, translate=True, scale=True, single_transform=False)
+    result = orthogonal_2sided(array_a, array_b, translate=True, scale=True, single_transform=False)
     # check transformation array and error
-    # Check orthogonality
-    # product is identity matrix and determinant is 1 or -1
-    assert_almost_equal(np.dot(array_u1, array_u1.T), np.eye(2), decimal=6)
-    assert_almost_equal(np.dot(array_u2, array_u2.T), np.eye(2), decimal=6)
-    assert_almost_equal(abs(np.linalg.det(array_u1)), 1.0, decimal=6)
-    assert_almost_equal(abs(np.linalg.det(array_u2)), 1.0, decimal=6)
-    # transformation should return zero error
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(2), decimal=6)
+    assert_almost_equal(np.dot(result[3], result[3].T), np.eye(2), decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result[3])), 1.0, decimal=6)
+    assert_almost_equal(result[4], 0, decimal=6)
 
 
 def test_two_sided_orthogonal_translate_scale_rotate_reflect():
@@ -310,15 +303,14 @@ def test_two_sided_orthogonal_translate_scale_rotate_reflect():
     shift = np.array([[16., 41., 33.], [16., 41., 33.], [16., 41., 33.]])
     array_b = np.dot(np.dot(ref, 23.5 * array_a + shift), rot)
     # compute procrustes transformation
-    _, _, array_u1, array_u2, e_opt = orthogonal_2sided(
-        array_a, array_b, translate=True, scale=True, single_transform=False)
+    result = orthogonal_2sided(array_a, array_b, translate=True, scale=True, single_transform=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u1, array_u1.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.dot(array_u2, array_u2.T), np.eye(3), decimal=6)
-    assert_almost_equal(abs(np.linalg.det(array_u1)), 1.0, decimal=6)
-    assert_almost_equal(abs(np.linalg.det(array_u2)), 1.0, decimal=6)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.dot(result[3], result[3].T), np.eye(3), decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result[3])), 1.0, decimal=6)
     # transformation should return zero error
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(result[4], 0, decimal=6)
 
 
 def test_two_sided_orthogonal_translate_scale_rotate_reflect_3by3():
@@ -332,15 +324,13 @@ def test_two_sided_orthogonal_translate_scale_rotate_reflect_3by3():
     shift = np.array([[146.56, 441.67, 343.56], [146.56, 441.67, 343.56], [146.56, 441.67, 343.56]])
     array_b = np.dot(np.dot(ref, 79.89 * array_a + shift), rot)
     # compute procrustes transformation
-    _, _, array_u1, array_u2, e_opt = orthogonal_2sided(
-        array_a, array_b, translate=True, scale=True, single_transform=False)
+    result = orthogonal_2sided(array_a, array_b, translate=True, scale=True, single_transform=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u1, array_u1.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.dot(array_u2, array_u2.T), np.eye(3), decimal=6)
-    assert_almost_equal(abs(np.linalg.det(array_u1)), 1.0, decimal=6)
-    assert_almost_equal(abs(np.linalg.det(array_u2)), 1.0, decimal=6)
-    # transformation should return zero error
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.dot(result[3], result[3].T), np.eye(3), decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result[3])), 1.0, decimal=6)
+    assert_almost_equal(result[4], 0, decimal=6)
 
 
 def test_two_sided_orthogonal_single_transformation_invalid_mode_argument():
@@ -360,26 +350,22 @@ def test_two_sided_orthogonal_single_transformation_identical():
     array_a = np.array([[2, 5, 4, 1], [5, 3, 1, 2], [8, 9, 1, 0], [1, 5, 6, 7]])
     array_a = np.dot(array_a, array_a.T)
     array_b = np.copy(array_a)
-
     # test the "exact" mode
-    # compute exact 2sided orthogonal Procrustes with one transformation
-    _, _, array_u, e_opt = orthogonal_2sided(array_a, array_b, single_transform=True, mode="exact")
+    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="exact")
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(4), decimal=8)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(4), decimal=8)
     # the rotations might not be unique
     # assert_almost_equal(abs(array_u), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
-    assert_almost_equal(e_opt, 0, decimal=8)
-
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
     # test the "approx" mode
-    # compute exact 2sided orthogonal Procrustes with one transformation
-    _, _, array_u, e_opt = orthogonal_2sided(
-        array_a, array_b, translate=False, scale=False, single_transform=True, mode="approx")
+    result = orthogonal_2sided(array_a, array_b, translate=False, scale=False,
+                               single_transform=True, mode="approx")
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(4), decimal=8)
-    assert_almost_equal(abs(array_u), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
-    assert_almost_equal(e_opt, 0, decimal=8)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(4), decimal=8)
+    assert_almost_equal(abs(result[2]), np.eye(4), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_rot_reflect_padded():
@@ -398,20 +384,15 @@ def test_two_sided_orthogonal_single_transformation_rot_reflect_padded():
     array_b = np.concatenate((array_b, np.zeros((3, 5))), axis=1)
     array_b = np.concatenate((array_b, np.zeros((5, 8))), axis=0)
 
-    # test the "exact" mode
-    # compute approximate Procrustes transformation
-    _, _, array_u, e_opt = orthogonal_2sided(array_a, array_b, single_transform=True, mode="exact")
-    # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
-    assert_almost_equal(e_opt, 0, decimal=8)
-
-    # test the "approx" mode
-    # compute approximate procrustes transformation
-    _, _, array_u, e_opt = orthogonal_2sided(array_a, array_b, single_transform=True, mode="approx")
-    # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
+    # check transformation array and error of "exact" mode
+    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="exact")
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
+    # check transformation array and error of "approx" mode
+    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="approx")
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_3by3():
@@ -428,23 +409,18 @@ def test_two_sided_orthogonal_single_transformation_scale_3by3():
     # define array_b by transforming scaled-and-translated array_a
     array_b = np.dot(np.dot(trans.T, 6.9 * array_a), trans)
 
-    # test the "exact" mode
-    # compute approximate procrustes transformation
-    _, _, array_u, e_opt = orthogonal_2sided(
-        array_a, array_b, translate=False, scale=True, single_transform=True, mode="exact")
-    # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
-    assert_almost_equal(e_opt, 0, decimal=8)
-
-    # test the "approx" mode
-    # compute approximate procrustes transformation
+    # check transformation array and error of "exact" mode
+    result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
+                               single_transform=True, mode="exact")
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
+    # check transformation array and error of "approx" mode
     _, _, array_u, e_opt = orthogonal_2sided(
         array_a, array_b, translate=True,
         scale=True, single_transform=True, mode="approx")
-    # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
     # error: 2.1162061737807796
 
 
@@ -462,21 +438,17 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
     # define array_b by transforming scaled array_a
     array_b = np.dot(np.dot(trans.T, 88.89 * array_a), trans)
 
-    # test the "exact" mode
-    # compute approximate procrustes transformation
-    _, _, array_u, e_opt = orthogonal_2sided(
-        array_a, array_b, translate=False, scale=True, single_transform=True, mode="exact")
-    # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(2), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
-    assert_almost_equal(e_opt, 0, decimal=8)
+    # check transformation array and error of "exact" mode
+    result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
+                               single_transform=True, mode="exact")
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(2), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
 
-    # test the "approx" mode
-    # compute approximate procrustes transformation
-    _, _, array_u, e_opt = orthogonal_2sided(array_a, array_b, single_transform=True, mode="approx")
-    # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(2), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
+    # check transformation array and error of "approx" mode
+    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="approx")
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(2), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
@@ -493,21 +465,16 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
     # define array_b by transforming scaled array_a
     array_b = np.dot(np.dot(trans.T, 6.9 * array_a), trans)
 
-    # test the "exact" mode
-    # compute approximate procrustes transformation
-    _, _, array_u, e_opt = orthogonal_2sided(
-        array_a, array_b, translate=False, scale=True, single_transform=True, mode="exact")
-    # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
-    assert_almost_equal(e_opt, 0, decimal=8)
-
-    # test the "approx" mode
-    # compute approximate procrustes transformation
-    _, _, array_u, e_opt = orthogonal_2sided(array_a, array_b, single_transform=True, mode="approx")
-    # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
+    # check transformation array and error of "exact" mode
+    result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
+                               single_transform=True, mode="exact")
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
+    # check transformation array and error of "approx" mode
+    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="approx")
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_random_orthogonal():
@@ -520,10 +487,8 @@ def test_two_sided_orthogonal_single_transformation_random_orthogonal():
                       [1, 0, 0, 0],
                       [0, 1, 0, 0]])
     array_b = np.dot(np.dot(ortho.T, array_a), ortho)
-    # test the "exact" mode
-    # compute approximate Procrustes transformation
-    _, _, array_u, e_opt = orthogonal_2sided(array_a, array_b, single_transform=True, mode="exact")
-    # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(array_u)), 1.0, decimal=8)
-    assert_almost_equal(e_opt, 0, decimal=8)
+    # check transformation array and error of "exact" mode
+    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="exact")
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(4), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -742,11 +742,10 @@ def test_permutation_2sided_regular():
                         [0, 1, 0, 0, 0],
                         [0, 0, 1, 0, 0],
                         [1, 0, 0, 0, 0]])
-    _, _, new_p, new_q, e_opt = permutation_2sided(array_m, array_n,
-                                                   transform_mode="double")
-    assert_almost_equal(new_p, array_p, decimal=6)
-    assert_almost_equal(new_q, array_q, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    result = permutation_2sided(array_m, array_n, transform_mode="double")
+    assert_almost_equal(result[2], array_p, decimal=6)
+    assert_almost_equal(result[3], array_q, decimal=6)
+    assert_almost_equal(result[4], 0, decimal=6)
 
 
 def test_permutation_2sided_regular2():
@@ -762,11 +761,10 @@ def test_permutation_2sided_regular2():
                         [0, 0, 0, 1]])
     array_q = array_p.T
     array_m = np.dot(np.dot(array_p, array_n), array_q)
-    _, _, new_p, new_q, e_opt = permutation_2sided(array_m, array_n,
-                                                   transform_mode="double")
-    assert_almost_equal(new_p, array_p, decimal=6)
-    assert_almost_equal(new_q, array_q, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    result = permutation_2sided(array_m, array_n, transform_mode="double")
+    assert_almost_equal(result[2], array_p, decimal=6)
+    assert_almost_equal(result[3], array_q, decimal=6)
+    assert_almost_equal(result[4], 0, decimal=6)
 
 
 def test_permutation_2sided_regular_unsquared():
@@ -776,12 +774,10 @@ def test_permutation_2sided_regular_unsquared():
                        [1, 0, 0, 0], [0, 0, 0, 1]])
     perm_q = np.array([[0, 1], [1, 0]])
     array_m = np.linalg.multi_dot([perm_p, array_n, perm_q])
-    _, _, new_p, new_q, e_opt = permutation_2sided(array_m, array_n,
-                                                   transform_mode="double",
-                                                   iteration=500)
-    assert_almost_equal(new_p, perm_p, decimal=6)
-    assert_almost_equal(new_q, perm_q, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    result = permutation_2sided(array_m, array_n, transform_mode="double", iteration=500)
+    assert_almost_equal(result[2], perm_p, decimal=6)
+    assert_almost_equal(result[3], perm_q, decimal=6)
+    assert_almost_equal(result[4], 0, decimal=6)
 
 
 def test_permutation_2sided_regular_unsquared_negative():
@@ -793,12 +789,10 @@ def test_permutation_2sided_regular_unsquared_negative():
     perm_p = np.random.permutation(np.eye(6, 6))
     perm_q = np.random.permutation(np.eye(4, 4))
     array_m = np.linalg.multi_dot([perm_p, array_n, perm_q])
-    _, _, new_p, new_q, e_opt = permutation_2sided(array_m, array_n,
-                                                   transform_mode="double",
-                                                   iteration=500)
-    assert_almost_equal(new_p, perm_p, decimal=6)
-    assert_almost_equal(new_q, perm_q, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    result = permutation_2sided(array_m, array_n, transform_mode="double", iteration=500)
+    assert_almost_equal(result[2], perm_p, decimal=6)
+    assert_almost_equal(result[3], perm_q, decimal=6)
+    assert_almost_equal(result[4], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_directed():
@@ -810,10 +804,9 @@ def test_permutation_2sided_4by4_directed():
     # permuted array_b
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Procrustes with no translate and scale
-    _, _, array_u, e_opt = permutation_2sided(array_a, array_b,
-                                              transform_mode="single_directed")
-    assert_almost_equal(array_u, perm, decimal=6)
-    assert_almost_equal(e_opt, 0., decimal=6)
+    result = permutation_2sided(array_a, array_b, transform_mode="single_directed")
+    assert_almost_equal(result[2], perm, decimal=6)
+    assert_almost_equal(result[3], 0., decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_symmetric():
@@ -825,10 +818,9 @@ def test_permutation_2sided_4by4_directed_symmetric():
     # permuted array_b
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Procrustes with no translate and scale
-    _, _, array_u, e_opt = permutation_2sided(array_a, array_b,
-                                              transform_mode="single_directed")
-    assert_almost_equal(array_u, perm, decimal=6)
-    assert_almost_equal(e_opt, 0., decimal=6)
+    result = permutation_2sided(array_a, array_b, transform_mode="single_directed")
+    assert_almost_equal(result[2], perm, decimal=6)
+    assert_almost_equal(result[3], 0., decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_loop():
@@ -841,11 +833,10 @@ def test_permutation_2sided_4by4_directed_loop():
         perm[np.arange(4), comb] = 1
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
-        # Check
-        _, _, array_u, e_opt = permutation_2sided(array_a, array_b,
-                                                  transform_mode="single_directed")
-        assert_almost_equal(array_u, perm, decimal=6)
-        assert_almost_equal(e_opt, 0, decimal=6)
+        # check
+        result = permutation_2sided(array_a, array_b, transform_mode="single_directed")
+        assert_almost_equal(result[2], perm, decimal=6)
+        assert_almost_equal(result[3], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_netative_loop():
@@ -858,11 +849,10 @@ def test_permutation_2sided_4by4_directed_netative_loop():
         perm[np.arange(4), comb] = 1
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
-        # Check
-        _, _, array_u, e_opt = permutation_2sided(array_a, array_b,
-                                                  transform_mode="single_directed")
-        assert_almost_equal(array_u, perm, decimal=6)
-        assert_almost_equal(e_opt, 0, decimal=6)
+        # check
+        result = permutation_2sided(array_a, array_b, transform_mode="single_directed")
+        assert_almost_equal(result[2], perm, decimal=6)
+        assert_almost_equal(result[3], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_translate_scale():
@@ -875,11 +865,10 @@ def test_permutation_2sided_4by4_directed_translate_scale():
     # permuted array_b
     array_b = np.dot(perm.T, np.dot(15.3 * array_a + 5.45, perm))
     # Procrustes with no translate and scale
-    _, _, array_u, e_opt = permutation_2sided(array_a, array_b,
-                                              transform_mode="single_directed",
-                                              translate=True, scale=True)
-    assert_almost_equal(array_u, perm, decimal=6)
-    assert_almost_equal(e_opt, 0., decimal=6)
+    result = permutation_2sided(array_a, array_b, transform_mode="single_directed", translate=True,
+                                scale=True)
+    assert_almost_equal(result[2], perm, decimal=6)
+    assert_almost_equal(result[3], 0., decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_translat_scale_padding():
@@ -896,11 +885,10 @@ def test_permutation_2sided_4by4_directed_translat_scale_padding():
     array_b = np.concatenate((array_b, np.zeros((4, 2))), axis=1)
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Procrustes with no translate and scale
-    _, _, array_u, e_opt = permutation_2sided(array_a, array_b,
-                                              transform_mode="single_directed",
-                                              translate=True, scale=True)
-    assert_almost_equal(array_u, perm, decimal=6)
-    assert_almost_equal(e_opt, 0., decimal=6)
+    result = permutation_2sided(array_a, array_b, transform_mode="single_directed", translate=True,
+                                scale=True)
+    assert_almost_equal(result[2], perm, decimal=6)
+    assert_almost_equal(result[3], 0., decimal=6)
 
 
 def test_permutation_2sided_explicit_4by4_loop():
@@ -914,10 +902,10 @@ def test_permutation_2sided_explicit_4by4_loop():
         perm[np.arange(4), comb] = 1
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
-        # Check
-        _, _, array_u, e_opt = permutation_2sided_explicit(array_a, array_b)
-        assert_almost_equal(array_u, perm, decimal=6)
-        assert_almost_equal(e_opt, 0, decimal=6)
+        # check
+        result = permutation_2sided_explicit(array_a, array_b)
+        assert_almost_equal(result[2], perm, decimal=6)
+        assert_almost_equal(result[3], 0, decimal=6)
 
 
 def test_permutation_2sided_explicit_4by4_loop_negative():
@@ -931,10 +919,10 @@ def test_permutation_2sided_explicit_4by4_loop_negative():
         perm[np.arange(4), comb] = 1
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
-        # Check
-        _, _, array_u, e_opt = permutation_2sided_explicit(array_a, array_b)
-        assert_almost_equal(array_u, perm, decimal=6)
-        assert_almost_equal(e_opt, 0, decimal=6)
+        # check
+        result = permutation_2sided_explicit(array_a, array_b)
+        assert_almost_equal(result[2], perm, decimal=6)
+        assert_almost_equal(result[3], 0, decimal=6)
 
 
 def test_permutation_2sided_explicit_4by4_translate_scale():
@@ -948,11 +936,10 @@ def test_permutation_2sided_explicit_4by4_translate_scale():
                       [3.14, 3.14, 3.14]])
     perm = np.array([[1., 0., 0.], [0., 0., 1.], [0., 1., 0.]])
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + shift), perm))
-    # Check
-    _, _, array_u, e_opt = permutation_2sided_explicit(
-        array_a, array_b, translate=True, scale=True)
-    assert_almost_equal(array_u, perm, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    # check
+    result = permutation_2sided_explicit(array_a, array_b, translate=True, scale=True)
+    assert_almost_equal(result[2], perm, decimal=6)
+    assert_almost_equal(result[3], 0, decimal=6)
 
 
 def test_permutation_2sided_explicit_4by4_translate_scale_zero_padding():
@@ -970,11 +957,10 @@ def test_permutation_2sided_explicit_4by4_translate_scale_zero_padding():
     # pad the matrices with zeros
     array_b = np.concatenate((array_b, np.zeros((4, 2))), axis=1)
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
-    # Check
-    _, _, array_u, e_opt = permutation_2sided_explicit(
-        array_a, array_b, translate=True, scale=True)
-    assert_almost_equal(array_u, perm, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    # check
+    result = permutation_2sided_explicit(array_a, array_b, translate=True, scale=True)
+    assert_almost_equal(result[2], perm, decimal=6)
+    assert_almost_equal(result[3], 0, decimal=6)
 
 
 def test_permutation_2sided_invalid_transform_mode():
@@ -986,9 +972,8 @@ def test_permutation_2sided_invalid_transform_mode():
     perm = np.array([[0., 0., 1., 0.], [1., 0., 0., 0.],
                      [0., 0., 0., 1.], [0., 1., 0., 0.]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
-    # Check
-    assert_raises(ValueError, permutation_2sided, array_a, array_b,
-                  transform_mode="haha")
+    # check
+    assert_raises(ValueError, permutation_2sided, array_a, array_b, transform_mode="haha")
 
 
 def test_permutation_2sided_add_noise_mode_umeyama():
@@ -1000,11 +985,10 @@ def test_permutation_2sided_add_noise_mode_umeyama():
                      [0., 0., 0., 1.], [0., 1., 0., 0.]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # test umeyama method
-    _, _, array_u, e_opt = permutation_2sided(array_a, array_b,
-                                              translate=False, scale=False,
-                                              mode="umeyama", add_noise=True)
-    assert_almost_equal(array_u, perm, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    result = permutation_2sided(array_a, array_b, translate=False, scale=False, mode="umeyama",
+                                add_noise=True)
+    assert_almost_equal(result[2], perm, decimal=6)
+    assert_almost_equal(result[3], 0, decimal=6)
 
 
 def test_permutation_2sided_add_noise_mode_umeyama_approx():
@@ -1016,9 +1000,7 @@ def test_permutation_2sided_add_noise_mode_umeyama_approx():
                      [0., 0., 0., 1.], [0., 1., 0., 0.]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # test umeyama method
-    _, _, array_u, e_opt = permutation_2sided(array_a, array_b,
-                                              translate=False, scale=False,
-                                              mode="umeyama_approx",
-                                              add_noise=True)
-    assert_almost_equal(array_u, perm, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    result = permutation_2sided(array_a, array_b, translate=False, scale=False,
+                                mode="umeyama_approx", add_noise=True)
+    assert_almost_equal(result[2], perm, decimal=6)
+    assert_almost_equal(result[3], 0, decimal=6)


### PR DESCRIPTION
This PR fixes the warnings raised by linters: `Possible unbalanced tuple unpacking with sequence defined at line...`. This is probably a short-term fix as it might be better to return a dictionary/class object for various Procrustes functions like `scipy.optimize` returned value.