### PR TITLE
Add generic Procrustes for least square problems

### DIFF
--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -29,7 +29,7 @@ from procrustes.utils import error, setup_input_arrays
 def generic(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
             pad_mode='row-col', translate=False, scale=False, check_finite=True):
     r"""
-    Generic right-sided Procrustes transformation.
+    Solve the generic right-sided Procrustes problem.
 
     The generic Procrustes solves the least squares optimization problem without any constraints. It
     assumed that each matrix has the same dimension, if not padding will occur.

--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -107,7 +107,7 @@ def generic(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
                                       pad_mode, translate, scale, check_finite)
     # compute the generic solution
-    a_inv = np.linalg.inv(np.dot(new_a.T, new_a))
+    a_inv = np.linalg.pinv(np.dot(new_a.T, new_a))
     array_x = np.linalg.multi_dot([a_inv, new_a.T, new_b])
     e_opt = error(new_a, new_b, array_x)
     return new_a, new_b, array_x, e_opt

--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -102,6 +102,7 @@ def generic(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     ----------
     1. Gower, J. C. Procrustes Methods. Wiley Interdisciplinary Reviews: Computational Statistics,
        2(4), 503-508, 2010.
+
     """
     # check inputs
     new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,

--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# The Procrustes library provides a set of functions for transforming
+# a matrix to make it as similar as possible to a target matrix.
+#
+# Copyright (C) 2017-2020 The Procrustes Development Team
+#
+# This file is part of Procrustes.
+#
+# Procrustes is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# Procrustes is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Generic Procrustes Module."""
+
+import numpy as np
+from procrustes.utils import error, setup_input_arrays
+
+
+def generic(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
+            pad_mode='row-col', translate=False, scale=False, check_finite=True):
+    r"""
+    Generic right-sided Procrustes transformation.
+
+    The generic Procrustes solves the least squares optimization problem without any constraints. It
+    assumed that each matrix has the same dimension, if not padding will occur.
+
+    Parameters
+    ----------
+    array_a : ndarray
+        The 2d-array :math:`\mathbf{A}_{m \times n}` which is going to be transformed.
+    array_b : ndarray
+        The 2d-array :math:`\mathbf{B}_{m \times n}` representing the reference.
+    remove_zero_col : bool, optional
+        If True, the zero columns on the right side will be removed.
+        Default=True.
+    remove_zero_row : bool, optional
+        If True, the zero rows on the top will be removed.
+        Default=True.
+    pad_mode : str, optional
+        Specifying how to pad the arrays, listed below. Default="row-col".
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
+    translate : bool, optional
+        If True, both arrays are translated to be centered at origin.
+        Default=False.
+    scale : bool, optional
+        If True, both arrays are column normalized to unity. Default=False.
+    check_finite : bool, optional
+        If true, convert the input to an array, checking for NaNs or Infs.
+        Default=True.
+
+    Returns
+    -------
+    new_a : ndarray
+        The transformed ndarray array_a.
+    new_b : ndarray
+        The transformed ndarray array_b.
+    array_x : ndarray
+        The optimum symmetric transformation array.
+    e_opt : float
+        One-sided Procrustes error.
+
+    Notes
+    -----
+    Given a source matrix :math:`\mathbf{A} \in \mathbb{R}^{m \times n}` and a target matrix
+    :math:`\mathbf{B} \in \mathbb{R}^{m \times n}`, find the transformation matrix
+    :math:`\mathbf{X} \in \mathbb{R}^{n \times n}` for which :math:`\mathbf{AX}` is as close as
+    possible to :math:`\mathbf{B}`. I.e.,
+
+    .. math::
+       \text{min} \quad \|\mathbf{A} \mathbf{X} - \mathbf{B}\|_{F}^2
+
+    The optimal transformation matrix :math:`\mathbf{X}` is given by
+
+    .. math::
+        \mathbf{X} = {(\mathbf{A}^{\top}\mathbf{A})}^{-1} \mathbf{A}^{\top} \mathbf{B}
+
+    References
+    ----------
+    1. Gower, J. C. Procrustes Methods. Wiley Interdisciplinary Reviews: Computational Statistics,
+       2(4), 503-508, 2010.
+    """
+    # check inputs
+    new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+                                      pad_mode, translate, scale, check_finite)
+    # compute the generic solution
+    a_inv = np.linalg.inv(np.dot(new_a.T, new_a))
+    array_x = np.linalg.multi_dot([a_inv, new_a.T, new_b])
+    e_opt = error(new_a, new_b, array_x)
+    return new_a, new_b, array_x, e_opt

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -92,7 +92,7 @@ def test_symmetric_transformed_scale():
                         [0.3, 0.7, 0.1, 0.7]])
     array_b = np.dot(array_a, array_x)
     # compute procrustes transformation
-    _, _, x_computed, e_opt = generic(array_a, array_b, translate=False, scale=True)
+    _, _, _, e_opt = generic(array_a, array_b, translate=False, scale=True)
     # check transformation is symmetric & error is zero
     assert_almost_equal(e_opt, 0.0, decimal=6)
 
@@ -108,6 +108,6 @@ def test_symmetric_transformed__traslate_scale():
                         [0.3, 0.7, 0.1, 0.7]])
     array_b = np.dot(4.5*array_a + 9, array_x)
     # compute procrustes transformation
-    _, _, x_computed, e_opt = generic(array_a, array_b, translate=True, scale=True)
+    _, _, _, e_opt = generic(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
     assert_almost_equal(e_opt, 0.0, decimal=6)

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -27,9 +27,9 @@ from numpy.testing import assert_almost_equal
 from procrustes.generic import generic
 
 
-def test_symmetric_transformed():
+def test_generic_transformed():
     r"""Test generic Procrustes with random matrices."""
-    # define arbitrary array and symmetric transformation
+    # define arbitrary array and random transformation
     array_a = np.array([[3, 3, 5, 9],
                         [2, 6, 9, 9],
                         [1, 3, 5, 2],
@@ -42,14 +42,14 @@ def test_symmetric_transformed():
     array_b = np.dot(array_a, array_x)
     # compute procrustes transformation
     _, _, x_computed, e_opt = generic(array_a, array_b, translate=False, scale=False)
-    # check transformation is symmetric & error is zero
+    # check transformation is right & error is zero
     assert_almost_equal(array_x, x_computed, decimal=6)
     assert_almost_equal(e_opt, 0.0, decimal=6)
 
 
-def test_symmetric_transformed_negative():
+def test_generic_transformed_negative():
     r"""Test generic Procrustes with negative matrices."""
-    # define arbitrary array and symmetric transformation
+    # define arbitrary array and random transformation
     np.random.seed(999)
     array_a = np.random.randint(low=-10, high=10, size=(5, 4))
     array_x = np.array([[0.3, 0., 0.3, 0.6],
@@ -59,14 +59,14 @@ def test_symmetric_transformed_negative():
     array_b = np.dot(array_a, array_x)
     # compute procrustes transformation
     _, _, x_computed, e_opt = generic(array_a, array_b, translate=False, scale=False)
-    # check transformation is symmetric & error is zero
+    # check transformation is right & error is zero
     assert_almost_equal(array_x, x_computed, decimal=6)
     assert_almost_equal(e_opt, 0.0, decimal=6)
 
 
-def test_symmetric_transformed_translate():
+def test_generic_transformed_translate():
     r"""Test generic Procrustes with translation."""
-    # define arbitrary array and symmetric transformation
+    # define arbitrary array and random transformation
     np.random.seed(999)
     array_a = np.random.randint(low=-10, high=10, size=(5, 4))
     array_x = np.array([[0.3, 0., 0.3, 0.6],
@@ -76,14 +76,14 @@ def test_symmetric_transformed_translate():
     array_b = np.dot(array_a, array_x) + 100
     # compute procrustes transformation
     _, _, x_computed, e_opt = generic(array_a, array_b, translate=True, scale=False)
-    # check transformation is symmetric & error is zero
+    # check transformation is right & error is zero
     assert_almost_equal(array_x, x_computed, decimal=6)
     assert_almost_equal(e_opt, 0.0, decimal=6)
 
 
-def test_symmetric_transformed_scale():
+def test_generic_transformed_scale():
     r"""Test generic Procrustes with scaling."""
-    # define arbitrary array and symmetric transformation
+    # define arbitrary array and transformation
     np.random.seed(999)
     array_a = np.random.randint(low=-10, high=10, size=(5, 4))
     array_x = np.array([[0.3, 0., 0.3, 0.6],
@@ -93,21 +93,35 @@ def test_symmetric_transformed_scale():
     array_b = np.dot(array_a, array_x)
     # compute procrustes transformation
     _, _, _, e_opt = generic(array_a, array_b, translate=False, scale=True)
-    # check transformation is symmetric & error is zero
+    # check transformation is right & error is zero
     assert_almost_equal(e_opt, 0.0, decimal=6)
 
 
-def test_symmetric_transformed__traslate_scale():
+def test_generic_transformed_translate_scale():
     r"""Test generic Procrustes with translation and scaling."""
-    # define arbitrary array and symmetric transformation
+    # define arbitrary array and random transformation
     np.random.seed(999)
     array_a = np.random.randint(low=-10, high=10, size=(5, 4))
     array_x = np.array([[0.3, 0., 0.3, 0.6],
                         [0.7, 0.3, 0., 0.8],
                         [0.4, 0., 0.4, 0.5],
                         [0.3, 0.7, 0.1, 0.7]])
-    array_b = np.dot(4.5*array_a + 9, array_x)
+    array_b = np.dot(4.5 * (array_a + 9), array_x)
     # compute procrustes transformation
     _, _, _, e_opt = generic(array_a, array_b, translate=True, scale=True)
-    # check transformation is symmetric & error is zero
+    # check transformation is error is zero
+    assert_almost_equal(e_opt, 0.0, decimal=6)
+
+
+def test_generic_random_transformation():
+    r"""Test generic Procrustes with randomized transformation matrices."""
+    # define arbitrary array and random transformation
+    np.random.seed(999)
+    array_a = np.random.randint(low=-10, high=10, size=(5, 4))
+    array_x = np.random.randint(low=0, high=20, size=(4, 4)) / 10
+    array_b = np.dot(array_a, array_x)
+    # compute procrustes transformation
+    _, _, x_computed, e_opt = generic(array_a, array_b, translate=False, scale=False)
+    # check transformation is right & error is zero
+    assert_almost_equal(array_x, x_computed, decimal=6)
     assert_almost_equal(e_opt, 0.0, decimal=6)

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# The Procrustes library provides a set of functions for transforming
+# a matrix to make it as similar as possible to a target matrix.
+#
+# Copyright (C) 2017-2020 The Procrustes Development Team
+#
+# This file is part of Procrustes.
+#
+# Procrustes is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# Procrustes is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Testings for generic Procrustes module."""
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+from procrustes.generic import generic
+
+
+def test_symmetric_transformed():
+    r"""Test generic Procrustes with random matrices."""
+    # define arbitrary array and symmetric transformation
+    array_a = np.array([[3, 3, 5, 9],
+                        [2, 6, 9, 9],
+                        [1, 3, 5, 2],
+                        [0, 4, 2, 9],
+                        [9, 6, 0, 3]])
+    array_x = np.array([[0.3, 0., 0.3, 0.6],
+                        [0.7, 0.3, 0., 0.8],
+                        [0.4, 0., 0.4, 0.5],
+                        [0.3, 0.7, 0.1, 0.7]])
+    array_b = np.dot(array_a, array_x)
+    # compute procrustes transformation
+    _, _, x_computed, e_opt = generic(array_a, array_b, translate=False, scale=False)
+    # check transformation is symmetric & error is zero
+    assert_almost_equal(array_x, x_computed, decimal=6)
+    assert_almost_equal(e_opt, 0.0, decimal=6)
+
+
+def test_symmetric_transformed_negative():
+    r"""Test generic Procrustes with negative matrices."""
+    # define arbitrary array and symmetric transformation
+    np.random.seed(999)
+    array_a = np.random.randint(low=-10, high=10, size=(5, 4))
+    array_x = np.array([[0.3, 0., 0.3, 0.6],
+                        [0.7, 0.3, 0., 0.8],
+                        [0.4, 0., 0.4, 0.5],
+                        [0.3, 0.7, 0.1, 0.7]])
+    array_b = np.dot(array_a, array_x)
+    # compute procrustes transformation
+    _, _, x_computed, e_opt = generic(array_a, array_b, translate=False, scale=False)
+    # check transformation is symmetric & error is zero
+    assert_almost_equal(array_x, x_computed, decimal=6)
+    assert_almost_equal(e_opt, 0.0, decimal=6)
+
+
+def test_symmetric_transformed_translate():
+    r"""Test generic Procrustes with translation."""
+    # define arbitrary array and symmetric transformation
+    np.random.seed(999)
+    array_a = np.random.randint(low=-10, high=10, size=(5, 4))
+    array_x = np.array([[0.3, 0., 0.3, 0.6],
+                        [0.7, 0.3, 0., 0.8],
+                        [0.4, 0., 0.4, 0.5],
+                        [0.3, 0.7, 0.1, 0.7]])
+    array_b = np.dot(array_a, array_x) + 100
+    # compute procrustes transformation
+    _, _, x_computed, e_opt = generic(array_a, array_b, translate=True, scale=False)
+    # check transformation is symmetric & error is zero
+    assert_almost_equal(array_x, x_computed, decimal=6)
+    assert_almost_equal(e_opt, 0.0, decimal=6)
+
+
+def test_symmetric_transformed_scale():
+    r"""Test generic Procrustes with scaling."""
+    # define arbitrary array and symmetric transformation
+    np.random.seed(999)
+    array_a = np.random.randint(low=-10, high=10, size=(5, 4))
+    array_x = np.array([[0.3, 0., 0.3, 0.6],
+                        [0.7, 0.3, 0., 0.8],
+                        [0.4, 0., 0.4, 0.5],
+                        [0.3, 0.7, 0.1, 0.7]])
+    array_b = np.dot(array_a, array_x)
+    # compute procrustes transformation
+    _, _, x_computed, e_opt = generic(array_a, array_b, translate=False, scale=True)
+    # check transformation is symmetric & error is zero
+    assert_almost_equal(e_opt, 0.0, decimal=6)
+
+
+def test_symmetric_transformed__traslate_scale():
+    r"""Test generic Procrustes with translation and scaling."""
+    # define arbitrary array and symmetric transformation
+    np.random.seed(999)
+    array_a = np.random.randint(low=-10, high=10, size=(5, 4))
+    array_x = np.array([[0.3, 0., 0.3, 0.6],
+                        [0.7, 0.3, 0., 0.8],
+                        [0.4, 0., 0.4, 0.5],
+                        [0.3, 0.7, 0.1, 0.7]])
+    array_b = np.dot(4.5*array_a + 9, array_x)
+    # compute procrustes transformation
+    _, _, x_computed, e_opt = generic(array_a, array_b, translate=True, scale=True)
+    # check transformation is symmetric & error is zero
+    assert_almost_equal(e_opt, 0.0, decimal=6)

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -256,8 +256,8 @@ def test_two_sided_orthogonal_rotate_reflect():
     # check transformation array orthogonality
     assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=6)
     assert_almost_equal(np.dot(result[3], result[3].T), np.eye(3), decimal=6)
-    assert_almost_equal(np.linalg.det(result[2]), 1.0, decimal=6)
-    assert_almost_equal(np.linalg.det(result[3]), 1.0, decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(result[2])), 1.0, decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(result[3])), 1.0, decimal=6)
     # transformation should return zero error
     assert_almost_equal(result[4], 0, decimal=6)
 


### PR DESCRIPTION
This generic Procrustes solves the problem of least squares and the solution is given by [Gower, J. C. Procrustes Methods. Wiley Interdisciplinary Reviews: Computational Statistics, 2(4), 503-508, 2010. ](https://onlinelibrary.wiley.com/doi/abs/10.1002/wics.107).  This implementation solves the problem of minimization of AX-B where A and B are the matrices of interest and X is the transformation matrix. 

I put this as a separate module as this generic one is unconstrained optimization and all other one sides Procrustes methods are just conditional optimization under special constraints, such as orthogonal, symmetric, et al. 

- [x] Implementation the codes in e56aa35
- [x] Add docstrings in e56aa35
- [x] Add test for generic Procrustes in 2988aa3
- [x] Fix pylint error in 7c6d3d2 and 4e4976e