### PR TITLE
Add k-opt heuristic algorithm for Procrustes

### DIFF
--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -132,7 +132,7 @@ def permutation(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     return new_a, new_b, array_u, e_opt
 
 
-def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
+def permutation_2sided(array_a, array_b, transform_mode="single",
                        remove_zero_col=True, remove_zero_row=True,
                        pad_mode="row-col", translate=False, scale=False,
                        mode="normal1", check_finite=True, iteration=500,
@@ -375,28 +375,29 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
     # B += np.min(A, B)
     # Do single-transformation computation if requested
     transform_mode = transform_mode.lower()
-    if transform_mode == "single_undirected":
-        # the initial guess
-        guess = _guess_initial_permutation(new_a, new_b, mode, add_noise)
-        # Compute the permutation matrix by iterations
-        array_u = _compute_transform(new_a, new_b, guess, tol, iteration)
-        e_opt = error(new_a, new_b, array_u, array_u)
-        # k-opt heuristic
-        if kopt:
-            array_u, e_opt = kopt_heuristic_single(array_u, new_a, new_b,
-                                                   e_opt, kopt_k=kopt_k, kopt_tol=kopt_tol)
-        return new_a, new_b, array_u, e_opt
-
-    elif transform_mode == "single_directed":
-        # the initial guess
-        guess = _2sided_1trans_initial_guess_directed(new_a, new_b)
-        # Compute the permutation matrix by iterations
-        array_u = _compute_transform_directed(new_a, new_b, guess, tol, iteration)
-        e_opt = error(new_a, new_b, array_u, array_u)
-        # k-opt heuristic
-        if kopt:
-            array_u, e_opt = kopt_heuristic_single(array_u, new_a, new_b,
-                                                   e_opt, kopt_k=kopt_k, kopt_tol=kopt_tol)
+    if transform_mode == "single":
+        # check if two matrices are symmetric within a relative tolerance and absolute tolerance.
+        if np.allclose(new_a, new_a.T, rtol=1.e-05, atol=1.e-08) and \
+             np.allclose(new_b, new_b.T, rtol=1.e-05, atol=1.e-08):
+            # the initial guess
+            guess = _guess_initial_permutation(new_a, new_b, mode, add_noise)
+            # Compute the permutation matrix by iterations
+            array_u = _compute_transform(new_a, new_b, guess, tol, iteration)
+            e_opt = error(new_a, new_b, array_u, array_u)
+            # k-opt heuristic
+            if kopt:
+                array_u, e_opt = kopt_heuristic_single(array_u, new_a, new_b, e_opt,
+                                                       kopt_k=kopt_k, kopt_tol=kopt_tol)
+        else:
+            # the initial guess
+            guess = _2sided_1trans_initial_guess_directed(new_a, new_b)
+            # Compute the permutation matrix by iterations
+            array_u = _compute_transform_directed(new_a, new_b, guess, tol, iteration)
+            e_opt = error(new_a, new_b, array_u, array_u)
+            # k-opt heuristic
+            if kopt:
+                array_u, e_opt = kopt_heuristic_single(array_u, new_a, new_b, e_opt,
+                                                       kopt_k=kopt_k, kopt_tol=kopt_tol)
         return new_a, new_b, array_u, e_opt
 
     # Do regular computation

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -406,11 +406,10 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         array_p, array_q, e_opt = _2sided_regular(array_m, array_n, tol, iteration)
         # perform k-opt heuristic search twice
         if kopt:
-            perm_p, perm_q, kopt_error = _kopt_heuristic_double(perm_p=array_p, perm_q=array_q,
-                                                                array_m=array_m, array_n=array_n,
-                                                                ref_error=e_opt, kopt_k=kopt_k,
-                                                                kopt_tol=kopt_tol)
-            array_p, array_q, e_opt = perm_p, perm_q, kopt_error
+            array_p, array_q, e_opt = _kopt_heuristic_double(perm_p=array_p, perm_q=array_q,
+                                                             array_m=array_m, array_n=array_n,
+                                                             ref_error=e_opt, kopt_k=kopt_k,
+                                                             kopt_tol=kopt_tol)
         return array_m, array_n, array_p, array_q, e_opt
     else:
         raise ValueError(

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -367,12 +367,11 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
                                       pad_mode, translate, scale, check_finite)
     # np.power() can not handle the negatives values
     # Try to convert the matrices to non-negative
-    maximum = np.max(np.abs(new_b)) if np.max(np.abs(new_b)) > np.max(
-        np.abs(new_a)) else np.max(np.abs(new_a))
-    new_a += maximum
-    new_b += maximum
-    # A += np.min(A, B)
-    # B += np.min(A, B)
+    # shift the the matrices to avoid negative values
+    # otherwise it will cause an error in the Eq. 28 in the research notes
+    maximum = max(np.abs((np.min(new_a), np.min(new_b))))
+    new_a = new_a.astype(np.float) + maximum
+    new_b = new_b.astype(np.float) + maximum
     # Do single-transformation computation if requested
     transform_mode = transform_mode.lower()
     if transform_mode == "single":
@@ -671,8 +670,6 @@ def _compute_transform(array_a, array_b, guess, tol, iteration):
 
 
 def _compute_transform_directed(array_a, array_b, guess, tol, iteration):
-    # shift the the matrices to avoid negative values
-    # otherwise it will cause an error in the Eq. 28
     p_old = guess
     change = np.inf
     step = 0

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -22,13 +22,12 @@
 # --
 """Permutation Procrustes Module."""
 
-import itertools as it
 from copy import deepcopy
+import itertools as it
 
 import numpy as np
-from scipy.optimize import linear_sum_assignment
-
 from procrustes.utils import error, setup_input_arrays
+from scipy.optimize import linear_sum_assignment
 
 __all__ = [
     "permutation",

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -25,10 +25,9 @@
 import itertools as it
 
 import numpy as np
-from scipy.optimize import linear_sum_assignment
-
 from procrustes.utils import (error, kopt_heuristic_double,
                               kopt_heuristic_single, setup_input_arrays)
+from scipy.optimize import linear_sum_assignment
 
 __all__ = [
     "permutation",
@@ -578,10 +577,10 @@ def _2sided_1trans_initial_guess_umeyama(array_a, array_b, add_noise):
     if add_noise:
         array_a = np.float_(array_a)
         array_a += np.random.random(array_a.shape) * np.trace(np.abs(array_a)) / \
-                   array_a.shape[0] * 1.e-8
+            array_a.shape[0] * 1.e-8
         array_b = np.float_(array_b)
         array_b += np.random.random(array_b.shape) * np.trace(np.abs(array_b)) / \
-                   array_b.shape[0] * 1.e-8
+            array_b.shape[0] * 1.e-8
     # calculate the eigenvalue decomposition of A and B
     _, array_ua = np.linalg.eigh(array_a)
     _, array_ub = np.linalg.eigh(array_b)

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -696,15 +696,15 @@ def _kopt_heuristic_single(perm, array_a, array_b, ref_error, k_opt):
 
     Parameters
     ----------
-    perm : np.ndarray
+    perm : ndarray
         The permutation array which remains to be processed with k-opt local search.
-    array_a : np.ndarray
+    array_a : ndarray
         The array to be permuted.
-    array_b : np.ndarray
+    array_b : ndarray
         The reference array.
     ref_error : float
         The reference error value.
-    k_opt : int, optional
+    k_opt : int
         Order of local search.
 
     Returns

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -783,6 +783,7 @@ def _kopt_heuristic_double(perm_p, perm_q, array_m, array_n, ref_error, k_opt, k
     num_row_right = perm_q.shape[0]
     kopt_error = ref_error
     # the left hand side permutation
+    # pylint: disable=too-many-nested-blocks
     for comb_left in it.combinations(np.arange(num_row_left), r=k_opt):
         for comb_perm_left in it.permutations(comb_left, r=k_opt):
             if comb_perm_left != comb_left:
@@ -801,7 +802,6 @@ def _kopt_heuristic_double(perm_p, perm_q, array_m, array_n, ref_error, k_opt, k
                                     break
 
                 perm_kopt_left[comb_left, :] = perm_kopt_left[comb_perm_left, :]
-                # perm_kopt_left[:, comb_left] = perm_kopt_left[:, comb_perm_left]
                 e_kopt_new_left = error(array_n, array_m, perm_kopt_left.T, perm_q)
                 if e_kopt_new_left < kopt_error:
                     perm_p = perm_kopt_left

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -790,7 +790,7 @@ def _kopt_heuristic_double(perm_p, perm_q, array_m, array_n, ref_error, k_opt, k
                 # the right hand side permutation
                 for comb_right in it.combinations(np.arange(num_row_right), r=k_opt):
                     for comb_perm_right in it.permutations(comb_right, r=k_opt):
-                        if comb_perm_right != comb_perm_right:
+                        if comb_perm_right != comb_right:
                             perm_kopt_right = deepcopy(perm_q)
                             perm_kopt_right[comb_right, :] = perm_kopt_right[comb_perm_right, :]
                             e_kopt_new_right = error(array_n, array_m, perm_p.T, perm_kopt_right)

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -23,6 +23,7 @@
 """Permutation Procrustes Module."""
 
 import itertools as it
+from copy import deepcopy
 
 import numpy as np
 from procrustes.utils import error, setup_input_arrays
@@ -132,7 +133,7 @@ def permutation(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
 
 
 def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
-                       remove_zero_col=True, remove_zero_row=True,
+                       heuristic=False, k_opt=3, remove_zero_col=True, remove_zero_row=True,
                        pad_mode="row-col", translate=False, scale=False,
                        mode="normal1", check_finite=True, iteration=500,
                        add_noise=False, tol=1.0e-8):
@@ -151,6 +152,10 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         for directed graph matching will be used. Otherwise, transform_mode="double", the
         two-sided permutation Procrustes with two transformations will be performed.
         Default="single_undirected".
+    heuristic : bool, optional
+        If True, the k_opt heuristic search will be performed. Default=False.
+    k-opt : int, optional
+        Defines the n-opt. Default=3.
     remove_zero_col : bool, optional
         If True, the zero columns on the right side will be removed. Default= True.
     remove_zero_row : bool, optional
@@ -373,6 +378,9 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         # Compute the permutation matrix by iterations
         array_u = _compute_transform(new_a, new_b, guess, tol, iteration)
         e_opt = error(new_a, new_b, array_u, array_u)
+        # k-opt heuristic
+        if heuristic:
+            array_u, e_opt = _kopt_heuristic_single(array_u, new_a, new_b, e_opt, k_opt=k_opt)
         return new_a, new_b, array_u, e_opt
 
     elif transform_mode == "single_directed":
@@ -381,6 +389,9 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         # Compute the permutation matrix by iterations
         array_u = _compute_transform_directed(new_a, new_b, guess, tol, iteration)
         e_opt = error(new_a, new_b, array_u, array_u)
+        # k-opt heuristic
+        if heuristic:
+            array_u, e_opt = _kopt_heuristic_single(array_u, new_a, new_b, e_opt, k_opt=k_opt)
         return new_a, new_b, array_u, e_opt
 
     # Do regular computation
@@ -388,6 +399,10 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         array_m = new_a
         array_n = new_b
         array_p, array_q, e_opt = _2sided_regular(array_m, array_n, tol, iteration)
+        # perform k-opt heuristic search twice
+        if heuristic:
+            raise ValueError("The k-opt heuristic for regular two sided "
+                             "permutations Procrustes not implemented.")
         return array_m, array_n, array_p, array_q, e_opt
     else:
         raise ValueError(
@@ -526,7 +541,7 @@ def _2sided_1trans_initial_guess_normal2(array_a):
 
     # use inf to represent the diagonal element
     a_inf = array_a - np.diag(np.diag(array_a)) + np.diag([-np.inf] * array_a.shape[0])
-    index_inf = np.argsort(-np.abs((a_inf)), axis=1)
+    index_inf = np.argsort(-np.abs(a_inf), axis=1)
 
     # the weight matrix
     weight_p = np.power(2, -0.5)
@@ -671,6 +686,51 @@ def _compute_transform_directed(array_a, array_b, guess, tol, iteration):
     _, _, p_opt, _ = permutation(np.eye(p_new.shape[0]), p_new)
 
     return p_opt
+
+
+def _kopt_heuristic_single(perm, array_a, array_b, ref_error, k_opt):
+    r"""
+    K-opt heuristic to improve the accuracy.
+
+    Perform k-opt local search with every possible valid combination of the swapping mechanism.
+
+    Parameters
+    ----------
+    perm : np.ndarray
+        The permutation array which remains to be processed with k-opt local search.
+    array_a : np.ndarray
+        The array to be permuted.
+    array_b : np.ndarray
+        The reference array.
+    ref_error : float
+        The reference error value.
+    k_opt : int, optional
+        Order of local search.
+
+    Returns
+    -------
+    perm : ndarray
+        The permutation array after optimal heuristic search.
+    kopt_error : float
+        The error distance of two arrays with the updated permutation array.
+    """
+    if k_opt < 2:
+        raise ValueError("K_opt value must be a integer greater than 2.")
+    num_row = perm.shape[0]
+    kopt_error = ref_error
+    # all the possible row-wise permutations
+    for comb in it.combinations(np.arange(num_row), r=k_opt):
+        for comb_perm in it.permutations(comb, r=k_opt):
+            if comb_perm != comb:
+                perm_kopt = deepcopy(perm)
+                perm_kopt[comb, :] = perm_kopt[comb_perm, :]
+                e_kopt_new = error(array_a, array_b, perm_kopt, perm_kopt)
+                if e_kopt_new < kopt_error:
+                    perm = perm_kopt
+                    kopt_error = e_kopt_new
+                    if kopt_error == 0:
+                        break
+    return perm, kopt_error
 
 
 def permutation_2sided_explicit(array_a, array_b,

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -22,12 +22,13 @@
 # --
 """Permutation Procrustes Module."""
 
-from copy import deepcopy
 import itertools as it
 
 import numpy as np
-from procrustes.utils import error, setup_input_arrays
 from scipy.optimize import linear_sum_assignment
+
+from procrustes.utils import (error, kopt_heuristic_double,
+                              kopt_heuristic_single, setup_input_arrays)
 
 __all__ = [
     "permutation",
@@ -383,8 +384,8 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         e_opt = error(new_a, new_b, array_u, array_u)
         # k-opt heuristic
         if kopt:
-            array_u, e_opt = _kopt_heuristic_single(array_u, new_a, new_b,
-                                                    e_opt, kopt_k=kopt_k, kopt_tol=kopt_tol)
+            array_u, e_opt = kopt_heuristic_single(array_u, new_a, new_b,
+                                                   e_opt, kopt_k=kopt_k, kopt_tol=kopt_tol)
         return new_a, new_b, array_u, e_opt
 
     elif transform_mode == "single_directed":
@@ -395,8 +396,8 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         e_opt = error(new_a, new_b, array_u, array_u)
         # k-opt heuristic
         if kopt:
-            array_u, e_opt = _kopt_heuristic_single(array_u, new_a, new_b,
-                                                    e_opt, kopt_k=kopt_k, kopt_tol=kopt_tol)
+            array_u, e_opt = kopt_heuristic_single(array_u, new_a, new_b,
+                                                   e_opt, kopt_k=kopt_k, kopt_tol=kopt_tol)
         return new_a, new_b, array_u, e_opt
 
     # Do regular computation
@@ -406,10 +407,10 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         array_p, array_q, e_opt = _2sided_regular(array_m, array_n, tol, iteration)
         # perform k-opt heuristic search twice
         if kopt:
-            array_p, array_q, e_opt = _kopt_heuristic_double(perm_p=array_p, perm_q=array_q,
-                                                             array_m=array_m, array_n=array_n,
-                                                             ref_error=e_opt, kopt_k=kopt_k,
-                                                             kopt_tol=kopt_tol)
+            array_p, array_q, e_opt = kopt_heuristic_double(perm_p=array_p, perm_q=array_q,
+                                                            array_m=array_m, array_n=array_n,
+                                                            ref_error=e_opt, kopt_k=kopt_k,
+                                                            kopt_tol=kopt_tol)
         return array_m, array_n, array_p, array_q, e_opt
     else:
         raise ValueError(
@@ -576,11 +577,11 @@ def _2sided_1trans_initial_guess_umeyama(array_a, array_b, add_noise):
     # add small random noise matrix when matrices are not diagonalizable
     if add_noise:
         array_a = np.float_(array_a)
-        array_a += np.random.random(array_a.shape) * np.trace(np.abs(array_a)) /\
-            array_a.shape[0] * 1.e-8
+        array_a += np.random.random(array_a.shape) * np.trace(np.abs(array_a)) / \
+                   array_a.shape[0] * 1.e-8
         array_b = np.float_(array_b)
-        array_b += np.random.random(array_b.shape) * np.trace(np.abs(array_b)) /\
-            array_b.shape[0] * 1.e-8
+        array_b += np.random.random(array_b.shape) * np.trace(np.abs(array_b)) / \
+                   array_b.shape[0] * 1.e-8
     # calculate the eigenvalue decomposition of A and B
     _, array_ua = np.linalg.eigh(array_a)
     _, array_ub = np.linalg.eigh(array_b)
@@ -693,123 +694,6 @@ def _compute_transform_directed(array_a, array_b, guess, tol, iteration):
     _, _, p_opt, _ = permutation(np.eye(p_new.shape[0]), p_new)
 
     return p_opt
-
-
-def _kopt_heuristic_single(perm, array_a, array_b, ref_error, kopt_k, kopt_tol):
-    r"""
-    K-opt heuristic to improve the accuracy.
-
-    Perform k-opt local search with every possible valid combination of the swapping mechanism.
-
-    Parameters
-    ----------
-    perm : ndarray
-        The permutation array which remains to be processed with k-opt local search.
-    array_a : ndarray
-        The array to be permuted.
-    array_b : ndarray
-        The reference array.
-    ref_error : float
-        The reference error value.
-    kopt_k : int
-        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
-        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
-    kopt_tol : float
-        Tolerance value to check if k-opt heuristic converges
-
-    Returns
-    -------
-    perm : ndarray
-        The permutation array after optimal heuristic search.
-    kopt_error : float
-        The error distance of two arrays with the updated permutation array.
-    """
-    if kopt_k < 2:
-        raise ValueError("K_opt value must be a integer greater than 2.")
-    num_row = perm.shape[0]
-    kopt_error = ref_error
-    # all the possible row-wise permutations
-    for comb in it.combinations(np.arange(num_row), r=kopt_k):
-        for comb_perm in it.permutations(comb, r=kopt_k):
-            if comb_perm != comb:
-                perm_kopt = deepcopy(perm)
-                perm_kopt[comb, :] = perm_kopt[comb_perm, :]
-                e_kopt_new = error(array_a, array_b, perm_kopt, perm_kopt)
-                if e_kopt_new < kopt_error:
-                    perm = perm_kopt
-                    kopt_error = e_kopt_new
-                    if kopt_error <= kopt_tol:
-                        break
-    return perm, kopt_error
-
-
-def _kopt_heuristic_double(perm_p, perm_q, array_m, array_n, ref_error, kopt_k, kopt_tol):
-    r"""
-    K-opt kopt for regular two-sided permutation Procrustes to improve the accuracy.
-
-    Perform k-opt local search with every possible valid combination of the swapping mechanism for
-    regular 2-sided permutation Procrustes.
-
-    Parameters
-    ----------
-    perm_p : ndarray
-        The left permutation array which remains to be processed with k-opt local search.
-    perm_q : ndarray
-        The right permutation array which remains to be processed with k-opt local search.
-    array_m : ndarray
-        The array to be permuted.
-    array_n : ndarray
-        The reference array.
-    ref_error : float
-        The reference error value.
-    kopt_k : int
-        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
-        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
-    kopt_tol : float
-        Tolerance value to check if k-opt heuristic converges.
-
-    Returns
-    -------
-    perm_kopt_p : ndarray
-        The left permutation array after optimal heuristic search.
-    perm_kopt_q : ndarray
-        The right permutation array after optimal heuristic search.
-    kopt_error : float
-        The error distance of two arrays with the updated permutation array.
-    """
-    if kopt_k < 2:
-        raise ValueError("Kopt_k value must be a integer greater than 2.")
-    num_row_left = perm_p.shape[0]
-    num_row_right = perm_q.shape[0]
-    kopt_error = ref_error
-    # the left hand side permutation
-    # pylint: disable=too-many-nested-blocks
-    for comb_left in it.combinations(np.arange(num_row_left), r=kopt_k):
-        for comb_perm_left in it.permutations(comb_left, r=kopt_k):
-            if comb_perm_left != comb_left:
-                perm_kopt_left = deepcopy(perm_p)
-                # the right hand side permutation
-                for comb_right in it.combinations(np.arange(num_row_right), r=kopt_k):
-                    for comb_perm_right in it.permutations(comb_right, r=kopt_k):
-                        if comb_perm_right != comb_right:
-                            perm_kopt_right = deepcopy(perm_q)
-                            perm_kopt_right[comb_right, :] = perm_kopt_right[comb_perm_right, :]
-                            e_kopt_new_right = error(array_n, array_m, perm_p.T, perm_kopt_right)
-                            if e_kopt_new_right < kopt_error:
-                                perm_q = perm_kopt_right
-                                kopt_error = e_kopt_new_right
-                                if kopt_error <= kopt_tol:
-                                    break
-
-                perm_kopt_left[comb_left, :] = perm_kopt_left[comb_perm_left, :]
-                e_kopt_new_left = error(array_n, array_m, perm_kopt_left.T, perm_q)
-                if e_kopt_new_left < kopt_error:
-                    perm_p = perm_kopt_left
-                    kopt_error = e_kopt_new_left
-                    if kopt_error <= kopt_tol:
-                        break
-
-    return perm_p, perm_q, kopt_error
 
 
 def permutation_2sided_explicit(array_a, array_b,

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -133,10 +133,10 @@ def permutation(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
 
 
 def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
-                       heuristic=False, k_opt=3, remove_zero_col=True, remove_zero_row=True,
+                       remove_zero_col=True, remove_zero_row=True,
                        pad_mode="row-col", translate=False, scale=False,
                        mode="normal1", check_finite=True, iteration=500,
-                       add_noise=False, tol=1.0e-8, kopt_tol=1.e-8):
+                       add_noise=False, tol=1.0e-8, heuristic=False, k_opt=3, kopt_tol=1.e-8):
     r"""
     Single sided permutation Procrustes.
 

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -384,7 +384,8 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         e_opt = error(new_a, new_b, array_u, array_u)
         # k-opt heuristic
         if heuristic:
-            array_u, e_opt = _kopt_heuristic_single(array_u, new_a, new_b, e_opt, k_opt=k_opt)
+            array_u, e_opt = _kopt_heuristic_single(array_u, new_a, new_b,
+                                                    e_opt, k_opt=k_opt, kopt_tol=kopt_tol)
         return new_a, new_b, array_u, e_opt
 
     elif transform_mode == "single_directed":

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -26,8 +26,9 @@ import itertools as it
 from copy import deepcopy
 
 import numpy as np
-from procrustes.utils import error, setup_input_arrays
 from scipy.optimize import linear_sum_assignment
+
+from procrustes.utils import error, setup_input_arrays
 
 __all__ = [
     "permutation",

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -1074,5 +1074,4 @@ def test_kopt_heuristic_double():
                                               array_m=arr_a, array_n=arr_b,
                                               ref_error=e_opt, k_opt=3, kopt_tol=1.e-8)
     assert kopt_error <= e_opt
-    # todo: check if the kopt_error can be zero
     assert kopt_error == 0

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -27,7 +27,6 @@ import itertools
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_raises
-
 from procrustes.permutation import (_2sided_1trans_initial_guess_normal1,
                                     _2sided_1trans_initial_guess_normal2,
                                     _2sided_1trans_initial_guess_umeyama,

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -223,7 +223,7 @@ def test_permutation_2sided_4by4_umeyama():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_directed", mode="umeyama")
+        array_a, array_b, transform_mode="single", mode="umeyama")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
 
@@ -240,8 +240,7 @@ def test_permutation_2sided_4by4_umeyama_loop():
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
-        _, _, array_u, e_opt = permutation_2sided(
-            array_a, array_b, transform_mode="single_undirected", mode="umeyama")
+        _, _, array_u, e_opt = permutation_2sided(array_a, array_b, transform_mode="single")
         assert_almost_equal(array_u, perm, decimal=6)
         assert_almost_equal(e_opt, 0, decimal=6)
 
@@ -259,7 +258,7 @@ def test_permutation_2sided_4by4_umeyama_loop_negative():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         _, _, array_u, e_opt = permutation_2sided(
-            array_a, array_b, transform_mode="single_undirected", mode="umeyama")
+            array_a, array_b, transform_mode="single", mode="umeyama")
         assert_almost_equal(array_u, perm, decimal=6)
         assert_almost_equal(e_opt, 0, decimal=6)
 
@@ -277,7 +276,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale():
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + shift), perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="umeyama")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -297,7 +296,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale_loop():
         array_b = np.dot(perm.T, np.dot(60 * array_a + 15, perm))
         # Check
         _, _, array_u, e_opt = permutation_2sided(
-            array_a, array_b, transform_mode="single_undirected",
+            array_a, array_b, transform_mode="single",
             translate=True, scale=True, mode="umeyama")
         assert_almost_equal(array_u, perm, decimal=6)
         assert_almost_equal(e_opt, 0, decimal=6)
@@ -322,7 +321,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="umeyama")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -339,7 +338,7 @@ def test_permutation_2sided_4by4_umeyama_approx():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         mode="umeyama_approx")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -358,7 +357,7 @@ def test_permutation_2sided_4by4_umeyama_approx_loop():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         _, _, array_u, e_opt = permutation_2sided(
-            array_a, array_b, transform_mode="single_undirected",
+            array_a, array_b, transform_mode="single",
             mode="umeyama_approx")
         assert_almost_equal(array_u, perm, decimal=6)
         assert_almost_equal(e_opt, 0, decimal=6)
@@ -377,7 +376,7 @@ def test_permutation_2sided_umeyama_approx_4by4_loop_negative():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         _, _, array_u, e_opt = permutation_2sided(
-            array_a, array_b, transform_mode="single_undirected",
+            array_a, array_b, transform_mode="single",
             mode="umeyama_approx")
         assert_almost_equal(array_u, perm, decimal=6)
         assert_almost_equal(e_opt, 0, decimal=6)
@@ -396,7 +395,7 @@ def test_permutation_2sided_4by4_umeyama_approx_translate_scale():
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + shift), perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="umeyama_approx")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -420,7 +419,7 @@ def test_permutation_2sided_4by4_umeyama_approx_translate_scale_zero_padding():
     # Check
     _, _, array_u, e_opt = permutation_2sided(
         array_a, array_b, translate=True, scale=True,
-        transform_mode="single_undirected", mode="umeyama_approx")
+        transform_mode="single", mode="umeyama_approx")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
 
@@ -435,7 +434,7 @@ def test_permutation_2sided_4by4_normal1():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected", mode="normal1")
+        array_a, array_b, transform_mode="single", mode="normal1")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
 
@@ -446,6 +445,7 @@ def test_permutation_2sided_4by4_normal1_loop():
     # array_a = np.array([[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
     np.random.seed(997)
     array_a = np.arange(16).reshape((4, 4))
+    # array_a = np.random.rand(4, 4)
     # check with all possible permutation matrices
     for comb in itertools.permutations(np.arange(4)):
         perm = np.zeros((4, 4))
@@ -455,10 +455,20 @@ def test_permutation_2sided_4by4_normal1_loop():
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
             _, _, array_u, e_opt = permutation_2sided(
-                array_a, array_b,
-                transform_mode="single_undirected", mode="normal1")
+                array_a, array_b, transform_mode="single", mode="normal1", iteration=1000)
+            print("array_a:", array_a)
+            print("array_b: ", array_b)
+            print("e_opt", e_opt)
             assert_almost_equal(array_u, perm, decimal=6)
             assert_almost_equal(e_opt, 0, decimal=6)
+
+            # try:
+            #     assert_almost_equal(array_u, perm, decimal=6)
+            #     assert_almost_equal(e_opt, 0, decimal=6)
+            # except AssertionError:
+            #     print("array_a:", array_a)
+            #     print("array_b: ", array_b)
+            #     print("e_opt", e_opt)
 
 
 def test_permutation_2sided_4by4_normal1_loop_negative():
@@ -476,7 +486,7 @@ def test_permutation_2sided_4by4_normal1_loop_negative():
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
             _, _, array_u, e_opt = permutation_2sided(
-                array_a, array_b, transform_mode="single_undirected",
+                array_a, array_b, transform_mode="single",
                 translate=True, scale=True, mode="normal1")
             assert_almost_equal(array_u, perm, decimal=6)
             assert_almost_equal(e_opt, 0, decimal=6)
@@ -492,7 +502,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale():
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + 3.14), perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal1")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -512,7 +522,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale_loop():
         array_b = np.dot(perm.T, np.dot(3 * array_a + 10, perm))
         # Check
         _, _, array_u, e_opt = permutation_2sided(
-            array_a, array_b, transform_mode="single_undirected",
+            array_a, array_b, transform_mode="single",
             translate=True, scale=True, mode="normal1")
         assert_almost_equal(array_u, perm, decimal=6)
         assert_almost_equal(e_opt, 0, decimal=6)
@@ -534,7 +544,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal1")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -560,7 +570,7 @@ def test_permutation_2sided_normal1_practical_example():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal1")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -576,7 +586,7 @@ def test_permutation_2sided_4by4_normal2():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected", mode="normal2")
+        array_a, array_b, transform_mode="single", mode="normal2")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
 
@@ -595,7 +605,7 @@ def test_permutation_2sided_4by4_normal2_loop():
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
             _, _, array_u, e_opt = permutation_2sided(
-                array_a, array_b, transform_mode="single_undirected",
+                array_a, array_b, transform_mode="single",
                 translate=True, scale=True, mode="normal2")
             assert_almost_equal(array_u, perm, decimal=6)
             assert_almost_equal(e_opt, 0, decimal=6)
@@ -616,7 +626,7 @@ def test_permutation_2sided_4by4_normal2_loop_negative():
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
             _, _, array_u, e_opt = permutation_2sided(
-                array_a, array_b, transform_mode="single_undirected",
+                array_a, array_b, transform_mode="single",
                 translate=True, scale=True, mode="normal2")
             assert_almost_equal(array_u, perm, decimal=6)
             assert_almost_equal(e_opt, 0, decimal=6)
@@ -631,7 +641,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale():
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + 3.14), perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal2")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -651,7 +661,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale_loop():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         _, _, array_u, e_opt = permutation_2sided(
-            array_a, array_b, transform_mode="single_undirected",
+            array_a, array_b, transform_mode="single",
             translate=True, scale=True, mode="normal2")
         assert_almost_equal(array_u, perm, decimal=6)
         assert_almost_equal(e_opt, 0, decimal=6)
@@ -673,7 +683,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal2")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -698,7 +708,7 @@ def test_permutation_2sided_normal2_practical_example():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
-        array_a, array_b, transform_mode="single_undirected",
+        array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal2")
     assert_almost_equal(array_u, perm, decimal=6)
     assert_almost_equal(e_opt, 0, decimal=6)
@@ -714,7 +724,7 @@ def test_permutation_2sided_invalid_mode_argument():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     assert_raises(ValueError, permutation_2sided, array_a,
-                  array_b, transform_mode="single_undirected", mode="nature")
+                  array_b, transform_mode="single", mode="nature")
 
 
 def test_permutation_2sided_regular():
@@ -806,7 +816,7 @@ def test_permutation_2sided_4by4_directed():
     # permuted array_b
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Procrustes with no translate and scale
-    result = permutation_2sided(array_a, array_b, transform_mode="single_directed")
+    result = permutation_2sided(array_a, array_b, transform_mode="single")
     assert_almost_equal(result[2], perm, decimal=6)
     assert_almost_equal(result[3], 0., decimal=6)
 
@@ -820,7 +830,7 @@ def test_permutation_2sided_4by4_directed_symmetric():
     # permuted array_b
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Procrustes with no translate and scale
-    result = permutation_2sided(array_a, array_b, transform_mode="single_directed")
+    result = permutation_2sided(array_a, array_b, transform_mode="single")
     assert_almost_equal(result[2], perm, decimal=6)
     assert_almost_equal(result[3], 0., decimal=6)
 
@@ -836,7 +846,7 @@ def test_permutation_2sided_4by4_directed_loop():
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # check
-        result = permutation_2sided(array_a, array_b, transform_mode="single_directed")
+        result = permutation_2sided(array_a, array_b, transform_mode="single")
         assert_almost_equal(result[2], perm, decimal=6)
         assert_almost_equal(result[3], 0, decimal=6)
 
@@ -852,7 +862,7 @@ def test_permutation_2sided_4by4_directed_netative_loop():
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # check
-        result = permutation_2sided(array_a, array_b, transform_mode="single_directed")
+        result = permutation_2sided(array_a, array_b, transform_mode="single")
         assert_almost_equal(result[2], perm, decimal=6)
         assert_almost_equal(result[3], 0, decimal=6)
 
@@ -867,7 +877,7 @@ def test_permutation_2sided_4by4_directed_translate_scale():
     # permuted array_b
     array_b = np.dot(perm.T, np.dot(15.3 * array_a + 5.45, perm))
     # Procrustes with no translate and scale
-    result = permutation_2sided(array_a, array_b, transform_mode="single_directed", translate=True,
+    result = permutation_2sided(array_a, array_b, transform_mode="single", translate=True,
                                 scale=True)
     assert_almost_equal(result[2], perm, decimal=6)
     assert_almost_equal(result[3], 0., decimal=6)
@@ -887,7 +897,7 @@ def test_permutation_2sided_4by4_directed_translat_scale_padding():
     array_b = np.concatenate((array_b, np.zeros((4, 2))), axis=1)
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Procrustes with no translate and scale
-    result = permutation_2sided(array_a, array_b, transform_mode="single_directed", translate=True,
+    result = permutation_2sided(array_a, array_b, transform_mode="single", translate=True,
                                 scale=True)
     assert_almost_equal(result[2], perm, decimal=6)
     assert_almost_equal(result[3], 0., decimal=6)

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -264,7 +264,7 @@ def test_permutation_2sided_4by4_umeyama_loop_negative():
 
 
 def test_permutation_2sided_4by4_umeyama_translate_scale():
-    r"""Test 2sided-perm with umeyama guess by 4by4 arrays with trans and scale."""
+    r"""Test 2sided-perm with umeyama guess by 3by3 arrays with trans and scale."""
     # define a random matrix
     array_a = np.array([[5., 2., 1.], [4., 6., 1.], [1., 6., 3.]])
     array_a = np.dot(array_a, array_a.T)
@@ -429,8 +429,8 @@ def test_permutation_2sided_4by4_normal1():
     # define a random matrix
     array_a = np.array([[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
     # define array_b by permuting array_a
-    perm = np.array([[0., 0., 1., 0.], [1., 0., 0., 0.], [0., 0., 0., 1.],
-                     [0., 1., 0., 0.]])
+    perm = np.array([[0., 0., 1., 0.], [1., 0., 0., 0.],
+                     [0., 0., 0., 1.], [0., 1., 0., 0.]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     _, _, array_u, e_opt = permutation_2sided(
@@ -442,7 +442,6 @@ def test_permutation_2sided_4by4_normal1():
 def test_permutation_2sided_4by4_normal1_loop():
     r"""Test 2sided-perm with "normal1" by 4by4 arrays with all permutations."""
     # define a random matrix
-    # array_a = np.array([[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
     np.random.seed(997)
     array_a = np.arange(16).reshape((4, 4))
     # array_a = np.random.rand(4, 4)
@@ -454,21 +453,11 @@ def test_permutation_2sided_4by4_normal1_loop():
             # get array_b by permutation
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
-            _, _, array_u, e_opt = permutation_2sided(
-                array_a, array_b, transform_mode="single", mode="normal1", iteration=1000)
-            print("array_a:", array_a)
-            print("array_b: ", array_b)
-            print("e_opt", e_opt)
+            _, _, array_u, e_opt = permutation_2sided(array_a, array_b,
+                                                      transform_mode="single",
+                                                      mode="normal1")
             assert_almost_equal(array_u, perm, decimal=6)
             assert_almost_equal(e_opt, 0, decimal=6)
-
-            # try:
-            #     assert_almost_equal(array_u, perm, decimal=6)
-            #     assert_almost_equal(e_opt, 0, decimal=6)
-            # except AssertionError:
-            #     print("array_a:", array_a)
-            #     print("array_b: ", array_b)
-            #     print("e_opt", e_opt)
 
 
 def test_permutation_2sided_4by4_normal1_loop_negative():
@@ -614,8 +603,7 @@ def test_permutation_2sided_4by4_normal2_loop():
 def test_permutation_2sided_4by4_normal2_loop_negative():
     r"""Test 2sided-perm with "normal2" by 4by4 negative arrays with all permutations."""
     # define a random matrix
-    array_a = np.array(
-        [[4, 5, -3, 3], [5, 7, 3, -5], [-3, 3, 2, 2], [3, -5, 2, 5]])
+    array_a = np.array([[4, 5, -3, 3], [5, 7, 3, -5], [-3, 3, 2, 2], [3, -5, 2, 5]])
     # check with all possible permutation matrices
     for comb in itertools.permutations(np.arange(4)):
         # Compute the permutation matrix
@@ -650,8 +638,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale():
 def test_permutation_2sided_4by4_normal2_translate_scale_loop():
     r"""Test 2sided-perm with "normal2" by 4by4 arrays with all permutations."""
     # define a random matrix
-    array_a = np.array(
-        [[4, 5, -3, 3], [5, 7, 3, -5], [-3, 3, 2, 2], [3, -5, 2, 5]])
+    array_a = np.array([[4, 5, -3, 3], [5, 7, 3, -5], [-3, 3, 2, 2], [3, -5, 2, 5]])
     # check with all possible permutation matrices
     for comb in itertools.permutations(np.arange(4)):
         # Compute the permutation matrix
@@ -670,8 +657,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale_loop():
 def test_permutation_2sided_4by4_normal2_translate_scale_zero_padding():
     r"""Test 2sided-perm with "normal2" by 4by4 with translation, scaling and zero paddings."""
     # define a random matrix
-    array_a = np.array(
-        [[4, 5, -3, 3], [5, 7, 3, -5], [-3, 3, 2, 2], [3, -5, 2, 5]])
+    array_a = np.array([[4, 5, -3, 3], [5, 7, 3, -5], [-3, 3, 2, 2], [3, -5, 2, 5]])
     # check with all possible permutation matrices
     perm = np.array([[0, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
     # Compute the translated, scaled matrix padded with zeros
@@ -719,8 +705,7 @@ def test_permutation_2sided_invalid_mode_argument():
     # define a random matrix
     array_a = np.array([[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
     # define array_b by permuting array_a
-    perm = np.array([[0., 0., 1., 0.], [1., 0., 0., 0.], [0., 0., 0., 1.],
-                     [0., 1., 0., 0.]])
+    perm = np.array([[0., 0., 1., 0.], [1., 0., 0., 0.], [0., 0., 0., 1.], [0., 1., 0., 0.]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     assert_raises(ValueError, permutation_2sided, array_a,
@@ -870,8 +855,8 @@ def test_permutation_2sided_4by4_directed_netative_loop():
 def test_permutation_2sided_4by4_directed_translate_scale():
     r"""Test 2sided-perm with "directed" by 4by4 with translation, scaling."""
     # A random array
-    array_a = np.array([[29, 79, 95, 83.], [37, 86, 67, 93.], [72, 85, 15, 3.],
-                        [38, 39, 58, 24.]])
+    array_a = np.array([[29, 79, 95, 83.], [37, 86, 67, 93.],
+                        [72, 85, 15, 3.],  [38, 39, 58, 24.]])
     # permutation
     perm = np.array([[0, 0, 0, 1], [0, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0]])
     # permuted array_b
@@ -883,7 +868,7 @@ def test_permutation_2sided_4by4_directed_translate_scale():
     assert_almost_equal(result[3], 0., decimal=6)
 
 
-def test_permutation_2sided_4by4_directed_translat_scale_padding():
+def test_permutation_2sided_4by4_directed_translate_scale_padding():
     r"""Test 2sided-perm with "directed" by 4by4 with translation, scaling and zero paddings."""
     # A random array
     array_a = np.array([[29, 79, 95, 83.], [37, 86, 67, 93.], [72, 85, 15, 3.], [38, 39, 58, 24.]])
@@ -978,8 +963,7 @@ def test_permutation_2sided_explicit_4by4_translate_scale_zero_padding():
 def test_permutation_2sided_invalid_transform_mode():
     r"""Test 2-sided permutation with invalid transform_mode."""
     # define a random matrix and symmetric matrix
-    array_a = np.array(
-        [[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
+    array_a = np.array([[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
     # define array_b by permuting array_a
     perm = np.array([[0., 0., 1., 0.], [1., 0., 0., 0.],
                      [0., 0., 0., 1.], [0., 1., 0., 0.]])
@@ -990,8 +974,7 @@ def test_permutation_2sided_invalid_transform_mode():
 
 def test_permutation_2sided_add_noise_mode_umeyama():
     r"""Test two sided permutation Procrustes with adding noise mode."""
-    array_a = np.array(
-        [[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
+    array_a = np.array([[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
     # define array_b by permuting array_a
     perm = np.array([[0., 0., 1., 0.], [1., 0., 0., 0.],
                      [0., 0., 0., 1.], [0., 1., 0., 0.]])
@@ -1005,8 +988,7 @@ def test_permutation_2sided_add_noise_mode_umeyama():
 
 def test_permutation_2sided_add_noise_mode_umeyama_approx():
     r"""Test two sided permutation Procrustes with adding noise mode."""
-    array_a = np.array(
-        [[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
+    array_a = np.array([[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
     # define array_b by permuting array_a
     perm = np.array([[0., 0., 1., 0.], [1., 0., 0., 0.],
                      [0., 0., 0., 1.], [0., 1., 0., 0.]])

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -1067,10 +1067,10 @@ def test_kopt_heuristic_double():
     perm_left, perm_right, kopt_error = _kopt_heuristic_double(perm_p=perm1_shuff,
                                                                perm_q=perm2_shuff,
                                                                array_m=arr_a, array_n=arr_b,
-                                                               ref_error=e_opt, k_opt=4,
+                                                               ref_error=e_opt, kopt_k=4,
                                                                kopt_tol=1.e-8)
     _, _, kopt_error = _kopt_heuristic_double(perm_p=perm_left, perm_q=perm_right,
                                               array_m=arr_a, array_n=arr_b,
-                                              ref_error=e_opt, k_opt=3, kopt_tol=1.e-8)
+                                              ref_error=e_opt, kopt_k=3, kopt_tol=1.e-8)
     assert kopt_error <= e_opt
     assert kopt_error == 0

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -21,13 +21,12 @@
 #
 # --
 """Testings for permutation module."""
+# pylint: disable=too-many-lines
 
 import itertools
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_raises
-
-# pylint: disable=too-many-lines
 from procrustes.permutation import (_2sided_1trans_initial_guess_normal1,
                                     _2sided_1trans_initial_guess_normal2,
                                     _2sided_1trans_initial_guess_umeyama,

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -856,7 +856,7 @@ def test_permutation_2sided_4by4_directed_translate_scale():
     r"""Test 2sided-perm with "directed" by 4by4 with translation, scaling."""
     # A random array
     array_a = np.array([[29, 79, 95, 83.], [37, 86, 67, 93.],
-                        [72, 85, 15, 3.],  [38, 39, 58, 24.]])
+                        [72, 85, 15, 3.], [38, 39, 58, 24.]])
     # permutation
     perm = np.array([[0, 0, 0, 1], [0, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0]])
     # permuted array_b

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -26,15 +26,13 @@
 import itertools
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_raises
+from numpy.testing import assert_almost_equal, assert_raises
+
 from procrustes.permutation import (_2sided_1trans_initial_guess_normal1,
                                     _2sided_1trans_initial_guess_normal2,
                                     _2sided_1trans_initial_guess_umeyama,
-                                    _kopt_heuristic_double,
-                                    _kopt_heuristic_single, permutation,
-                                    permutation_2sided,
+                                    permutation, permutation_2sided,
                                     permutation_2sided_explicit)
-from procrustes.utils import error
 
 
 def test_permutation_columns():
@@ -1009,68 +1007,3 @@ def test_permutation_2sided_add_noise_mode_umeyama_approx():
                                 mode="umeyama_approx", add_noise=True)
     assert_almost_equal(result[2], perm, decimal=6)
     assert_almost_equal(result[3], 0, decimal=6)
-
-
-def test_kopt_heuristic_single():
-    r"""Test k-opt heuristic search algorithm."""
-    arr_a = np.array([[3, 6, 1, 0, 7],
-                      [4, 5, 2, 7, 6],
-                      [8, 6, 6, 1, 7],
-                      [4, 4, 7, 9, 4],
-                      [4, 8, 0, 3, 1]])
-    arr_b = np.array([[1, 8, 0, 4, 3],
-                      [6, 5, 2, 4, 7],
-                      [7, 6, 6, 8, 1],
-                      [7, 6, 1, 3, 0],
-                      [4, 4, 7, 4, 9]])
-    perm_guess = np.array([[0, 0, 1, 0, 0],
-                           [1, 0, 0, 0, 0],
-                           [0, 0, 0, 1, 0],
-                           [0, 0, 0, 0, 1],
-                           [0, 1, 0, 0, 0]])
-    perm_exact = np.array([[0, 0, 0, 1, 0],
-                           [0, 1, 0, 0, 0],
-                           [0, 0, 1, 0, 0],
-                           [0, 0, 0, 0, 1],
-                           [1, 0, 0, 0, 0]])
-    error_old = error(arr_a, arr_b, perm_guess, perm_guess)
-    perm, kopt_error = _kopt_heuristic_single(perm_guess, arr_a, arr_b,
-                                              error_old, 3, kopt_tol=1.e-8)
-    assert_equal(perm, perm_exact)
-    assert kopt_error == 0
-    # test the error exceptions
-    assert_raises(ValueError, _kopt_heuristic_single, perm_guess,
-                  arr_a, arr_b, error_old, 1, kopt_tol=1.e-8)
-
-
-def test_kopt_heuristic_double():
-    r"""Test double sided k-opt heuristic search algorithm."""
-    np.random.seed(998)
-    arr_b = np.random.randint(low=-10, high=10, size=(4, 3)).astype(np.float)
-    perm1 = np.array([[0., 0., 0., 1.],
-                      [0., 1., 0., 0.],
-                      [1., 0., 0., 0.],
-                      [0., 0., 1., 0.]])
-    perm2 = np.array([[0., 0., 1.],
-                      [1., 0., 0.],
-                      [0., 1., 0.]])
-    arr_a = np.linalg.multi_dot([perm1.T, arr_b, perm2])
-    # shuffle the permutation matrices
-    perm1_shuff = np.array([[0., 0., 0., 1.],
-                            [1., 0., 0., 0.],
-                            [0., 1., 0., 0.],
-                            [0., 0., 1., 0.]])
-    perm2_shuff = np.array([[1., 0., 0.],
-                            [0., 0., 1.],
-                            [0., 1., 0.]])
-    e_opt = error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
-    perm_left, perm_right, kopt_error = _kopt_heuristic_double(perm_p=perm1_shuff,
-                                                               perm_q=perm2_shuff,
-                                                               array_m=arr_a, array_n=arr_b,
-                                                               ref_error=e_opt, kopt_k=4,
-                                                               kopt_tol=1.e-8)
-    _, _, kopt_error = _kopt_heuristic_double(perm_p=perm_left, perm_q=perm_right,
-                                              array_m=arr_a, array_n=arr_b,
-                                              ref_error=e_opt, kopt_k=3, kopt_tol=1.e-8)
-    assert kopt_error <= e_opt
-    assert kopt_error == 0

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -23,7 +23,11 @@
 """Utils module for Procrustes."""
 
 import numpy as np
-from procrustes.utils import _hide_zero_padding, _scale_array, _translate_array, _zero_padding
+from numpy.testing import assert_equal, assert_raises
+
+from procrustes.utils import (_hide_zero_padding, _scale_array,
+                              _translate_array, _zero_padding, error,
+                              kopt_heuristic_double, kopt_heuristic_single)
 
 
 def test_zero_padding_rows():
@@ -320,3 +324,68 @@ def test_scale_array():
     # array_trans_scale should be identical to array after the above analysis
     expected = array_a
     assert (abs(predicted - expected) < 1.e-10).all()
+
+
+def test_kopt_heuristic_single():
+    r"""Test k-opt heuristic search algorithm."""
+    arr_a = np.array([[3, 6, 1, 0, 7],
+                      [4, 5, 2, 7, 6],
+                      [8, 6, 6, 1, 7],
+                      [4, 4, 7, 9, 4],
+                      [4, 8, 0, 3, 1]])
+    arr_b = np.array([[1, 8, 0, 4, 3],
+                      [6, 5, 2, 4, 7],
+                      [7, 6, 6, 8, 1],
+                      [7, 6, 1, 3, 0],
+                      [4, 4, 7, 4, 9]])
+    perm_guess = np.array([[0, 0, 1, 0, 0],
+                           [1, 0, 0, 0, 0],
+                           [0, 0, 0, 1, 0],
+                           [0, 0, 0, 0, 1],
+                           [0, 1, 0, 0, 0]])
+    perm_exact = np.array([[0, 0, 0, 1, 0],
+                           [0, 1, 0, 0, 0],
+                           [0, 0, 1, 0, 0],
+                           [0, 0, 0, 0, 1],
+                           [1, 0, 0, 0, 0]])
+    error_old = error(arr_a, arr_b, perm_guess, perm_guess)
+    perm, kopt_error = kopt_heuristic_single(perm_guess, arr_a, arr_b,
+                                             error_old, 3, kopt_tol=1.e-8)
+    assert_equal(perm, perm_exact)
+    assert kopt_error == 0
+    # test the error exceptions
+    assert_raises(ValueError, kopt_heuristic_single, perm_guess,
+                  arr_a, arr_b, error_old, 1, kopt_tol=1.e-8)
+
+
+def test_kopt_heuristic_double():
+    r"""Test double sided k-opt heuristic search algorithm."""
+    np.random.seed(998)
+    arr_b = np.random.randint(low=-10, high=10, size=(4, 3)).astype(np.float)
+    perm1 = np.array([[0., 0., 0., 1.],
+                      [0., 1., 0., 0.],
+                      [1., 0., 0., 0.],
+                      [0., 0., 1., 0.]])
+    perm2 = np.array([[0., 0., 1.],
+                      [1., 0., 0.],
+                      [0., 1., 0.]])
+    arr_a = np.linalg.multi_dot([perm1.T, arr_b, perm2])
+    # shuffle the permutation matrices
+    perm1_shuff = np.array([[0., 0., 0., 1.],
+                            [1., 0., 0., 0.],
+                            [0., 1., 0., 0.],
+                            [0., 0., 1., 0.]])
+    perm2_shuff = np.array([[1., 0., 0.],
+                            [0., 0., 1.],
+                            [0., 1., 0.]])
+    e_opt = error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
+    perm_left, perm_right, kopt_error = kopt_heuristic_double(perm_p=perm1_shuff,
+                                                              perm_q=perm2_shuff,
+                                                              array_m=arr_a, array_n=arr_b,
+                                                              ref_error=e_opt, kopt_k=4,
+                                                              kopt_tol=1.e-8)
+    _, _, kopt_error = kopt_heuristic_double(perm_p=perm_left, perm_q=perm_right,
+                                             array_m=arr_a, array_n=arr_b,
+                                             ref_error=e_opt, kopt_k=3, kopt_tol=1.e-8)
+    assert kopt_error <= e_opt
+    assert kopt_error == 0

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -24,7 +24,6 @@
 
 import numpy as np
 from numpy.testing import assert_equal, assert_raises
-
 from procrustes.utils import (_hide_zero_padding, _scale_array,
                               _translate_array, _zero_padding, error,
                               kopt_heuristic_double, kopt_heuristic_single)

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -348,13 +348,13 @@ def test_kopt_heuristic_single():
                            [0, 0, 0, 0, 1],
                            [1, 0, 0, 0, 0]])
     error_old = error(arr_a, arr_b, perm_guess, perm_guess)
-    perm, kopt_error = kopt_heuristic_single(perm_guess, arr_a, arr_b,
-                                             error_old, 3, kopt_tol=1.e-8)
+    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, error_old,
+                                             perm_guess, 3, kopt_tol=1.e-8)
     assert_equal(perm, perm_exact)
     assert kopt_error == 0
     # test the error exceptions
-    assert_raises(ValueError, kopt_heuristic_single, perm_guess,
-                  arr_a, arr_b, error_old, 1, kopt_tol=1.e-8)
+    assert_raises(ValueError, kopt_heuristic_single, arr_a,
+                  arr_b, error_old, perm_guess, 1, kopt_tol=1.e-8)
 
 
 def test_kopt_heuristic_double():

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -340,21 +340,22 @@ def _check_arraytypes(*args):
         raise TypeError("Matrix inputs must be 2-dimensional arrays")
 
 
-def kopt_heuristic_single(perm, array_a, array_b, ref_error, kopt_k=3, kopt_tol=1.e-8):
+def kopt_heuristic_single(array_a, array_b, ref_error, perm=None, kopt_k=3, kopt_tol=1.e-8):
     r"""K-opt heuristic to improve the accuracy for two-sided permutation with one transformation.
 
     Perform k-opt local search with every possible valid combination of the swapping mechanism.
 
     Parameters
     ----------
-    perm : ndarray
-        The permutation array which remains to be processed with k-opt local search.
     array_a : ndarray
         The array to be permuted.
     array_b : ndarray
         The reference array.
     ref_error : float
         The reference error value.
+    perm : ndarray, optional
+        The permutation array which remains to be processed with k-opt local search. Default is the
+        identity matrix with the same shape of array_a.
     kopt_k : int, optional
         Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
         search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
@@ -369,7 +370,10 @@ def kopt_heuristic_single(perm, array_a, array_b, ref_error, kopt_k=3, kopt_tol=
         The error distance of two arrays with the updated permutation array.
     """
     if kopt_k < 2:
-        raise ValueError("K_opt value must be a integer greater than 2.")
+        raise ValueError("Kopt_k value must be a integer greater than 2.")
+    # if perm is not specified, use the identity matrix as default
+    if perm is None:
+        perm = np.identity(np.shape(array_a)[0])
     num_row = perm.shape[0]
     kopt_error = ref_error
     # all the possible row-wise permutations
@@ -387,7 +391,9 @@ def kopt_heuristic_single(perm, array_a, array_b, ref_error, kopt_k=3, kopt_tol=
     return perm, kopt_error
 
 
-def kopt_heuristic_double(perm_p, perm_q, array_m, array_n, ref_error, kopt_k=3, kopt_tol=1.e-8):
+def kopt_heuristic_double(array_m, array_n, ref_error,
+                          perm_p=None, perm_q=None,
+                          kopt_k=3, kopt_tol=1.e-8):
     r"""
     K-opt kopt for regular two-sided permutation Procrustes to improve the accuracy.
 
@@ -396,16 +402,18 @@ def kopt_heuristic_double(perm_p, perm_q, array_m, array_n, ref_error, kopt_k=3,
 
     Parameters
     ----------
-    perm_p : ndarray
-        The left permutation array which remains to be processed with k-opt local search.
-    perm_q : ndarray
-        The right permutation array which remains to be processed with k-opt local search.
     array_m : ndarray
         The array to be permuted.
     array_n : ndarray
         The reference array.
     ref_error : float
         The reference error value.
+    perm_p : ndarray, optional
+        The left permutation array which remains to be processed with k-opt local search. Default
+        is the identity matrix with the same shape of array_m.
+    perm_q : ndarray, optional
+        The right permutation array which remains to be processed with k-opt local search. Default
+        is the identity matrix with the same shape of array_m.
     kopt_k : int, optional
         Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
         search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
@@ -423,6 +431,13 @@ def kopt_heuristic_double(perm_p, perm_q, array_m, array_n, ref_error, kopt_k=3,
     """
     if kopt_k < 2:
         raise ValueError("Kopt_k value must be a integer greater than 2.")
+    # if perm_p is not specified, use the identity matrix as default
+    if perm_p is None:
+        perm_p = np.identity(np.shape(array_m)[0])
+    # if perm_p is not specified, use the identity matrix as default
+    if perm_q is None:
+        perm_q = np.identity(np.shape(array_m)[0])
+
     num_row_left = perm_p.shape[0]
     num_row_right = perm_q.shape[0]
     kopt_error = ref_error

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -32,10 +32,12 @@ setup_input_arrays : Setups up the arrays for all Procrustes methods.  It checks
                     arrays if specified.
 
 """
+import itertools as it
+from copy import deepcopy
 
 import numpy as np
 
-__all__ = ["error", "setup_input_arrays"]
+__all__ = ["error", "setup_input_arrays", "kopt_heuristic_single", "kopt_heuristic_double"]
 
 
 def _zero_padding(array_a, array_b, pad_mode="row-col"):
@@ -336,3 +338,121 @@ def _check_arraytypes(*args):
         raise TypeError("Matrix inputs must be NumPy arrays")
     if any(x.ndim != 2 for x in args):
         raise TypeError("Matrix inputs must be 2-dimensional arrays")
+
+
+def kopt_heuristic_single(perm, array_a, array_b, ref_error, kopt_k=3, kopt_tol=1.e-8):
+    r"""
+    K-opt heuristic to improve the accuracy for two-sided permutation Procrustes with one
+    transformation.
+
+    Perform k-opt local search with every possible valid combination of the swapping mechanism.
+
+    Parameters
+    ----------
+    perm : ndarray
+        The permutation array which remains to be processed with k-opt local search.
+    array_a : ndarray
+        The array to be permuted.
+    array_b : ndarray
+        The reference array.
+    ref_error : float
+        The reference error value.
+    kopt_k : int, optional
+        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
+        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
+    kopt_tol : float, optional
+        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
+
+    Returns
+    -------
+    perm : ndarray
+        The permutation array after optimal heuristic search.
+    kopt_error : float
+        The error distance of two arrays with the updated permutation array.
+    """
+    if kopt_k < 2:
+        raise ValueError("K_opt value must be a integer greater than 2.")
+    num_row = perm.shape[0]
+    kopt_error = ref_error
+    # all the possible row-wise permutations
+    for comb in it.combinations(np.arange(num_row), r=kopt_k):
+        for comb_perm in it.permutations(comb, r=kopt_k):
+            if comb_perm != comb:
+                perm_kopt = deepcopy(perm)
+                perm_kopt[comb, :] = perm_kopt[comb_perm, :]
+                e_kopt_new = error(array_a, array_b, perm_kopt, perm_kopt)
+                if e_kopt_new < kopt_error:
+                    perm = perm_kopt
+                    kopt_error = e_kopt_new
+                    if kopt_error <= kopt_tol:
+                        break
+    return perm, kopt_error
+
+
+def kopt_heuristic_double(perm_p, perm_q, array_m, array_n, ref_error, kopt_k=3, kopt_tol=1.e-8):
+    r"""
+    K-opt kopt for regular two-sided permutation Procrustes to improve the accuracy.
+
+    Perform k-opt local search with every possible valid combination of the swapping mechanism for
+    regular 2-sided permutation Procrustes.
+
+    Parameters
+    ----------
+    perm_p : ndarray
+        The left permutation array which remains to be processed with k-opt local search.
+    perm_q : ndarray
+        The right permutation array which remains to be processed with k-opt local search.
+    array_m : ndarray
+        The array to be permuted.
+    array_n : ndarray
+        The reference array.
+    ref_error : float
+        The reference error value.
+    kopt_k : int, optional
+        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
+        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
+    kopt_tol : float, optional
+        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
+
+    Returns
+    -------
+    perm_kopt_p : ndarray
+        The left permutation array after optimal heuristic search.
+    perm_kopt_q : ndarray
+        The right permutation array after optimal heuristic search.
+    kopt_error : float
+        The error distance of two arrays with the updated permutation array.
+    """
+    if kopt_k < 2:
+        raise ValueError("Kopt_k value must be a integer greater than 2.")
+    num_row_left = perm_p.shape[0]
+    num_row_right = perm_q.shape[0]
+    kopt_error = ref_error
+    # the left hand side permutation
+    # pylint: disable=too-many-nested-blocks
+    for comb_left in it.combinations(np.arange(num_row_left), r=kopt_k):
+        for comb_perm_left in it.permutations(comb_left, r=kopt_k):
+            if comb_perm_left != comb_left:
+                perm_kopt_left = deepcopy(perm_p)
+                # the right hand side permutation
+                for comb_right in it.combinations(np.arange(num_row_right), r=kopt_k):
+                    for comb_perm_right in it.permutations(comb_right, r=kopt_k):
+                        if comb_perm_right != comb_right:
+                            perm_kopt_right = deepcopy(perm_q)
+                            perm_kopt_right[comb_right, :] = perm_kopt_right[comb_perm_right, :]
+                            e_kopt_new_right = error(array_n, array_m, perm_p.T, perm_kopt_right)
+                            if e_kopt_new_right < kopt_error:
+                                perm_q = perm_kopt_right
+                                kopt_error = e_kopt_new_right
+                                if kopt_error <= kopt_tol:
+                                    break
+
+                perm_kopt_left[comb_left, :] = perm_kopt_left[comb_perm_left, :]
+                e_kopt_new_left = error(array_n, array_m, perm_kopt_left.T, perm_q)
+                if e_kopt_new_left < kopt_error:
+                    perm_p = perm_kopt_left
+                    kopt_error = e_kopt_new_left
+                    if kopt_error <= kopt_tol:
+                        break
+
+    return perm_p, perm_q, kopt_error

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -32,8 +32,8 @@ setup_input_arrays : Setups up the arrays for all Procrustes methods.  It checks
                     arrays if specified.
 
 """
-import itertools as it
 from copy import deepcopy
+import itertools as it
 
 import numpy as np
 
@@ -341,9 +341,7 @@ def _check_arraytypes(*args):
 
 
 def kopt_heuristic_single(perm, array_a, array_b, ref_error, kopt_k=3, kopt_tol=1.e-8):
-    r"""
-    K-opt heuristic to improve the accuracy for two-sided permutation Procrustes with one
-    transformation.
+    r"""K-opt heuristic to improve the accuracy for two-sided permutation with one transformation.
 
     Perform k-opt local search with every possible valid combination of the swapping mechanism.
 


### PR DESCRIPTION
The k-opt heuristic local search algorithm is the most widely used heuristic method for the traveling salesman problem (TSP). The idea is to swap the local k items and see if the distance is improved. If so, the new swap is accepted. Two-sided permutation Procrustes problem share the same mathematical formula with TSP, which is suggesting we can use k-opt heuristic local search to improve the results of 2-sided permutation Procrustes problem, especially when the permutation matrices are the same on left- and right-hand side.

- [x] Add k-opt heuristic for 2-sided permutation Procrustes with one transformation in a68dcc0
- [x] Add test for k-opt heuristic in c12aedf
- [x] Fix docstrings for k-opt heuristic for 2-sided permutation Procrustes with one transformation in d6bd691
- [x] Add Add kopt tolerance argument in c12aedf
- [x] Add k-opt heuristic for regular 2-sided permutation in 360d41f
- [x] Add test for regular 2sided k-opt in 3c5d2c5

According to the results we have, the heuristic for regular 2-sided permutation Procrustes (solved with a flip-flop algorithm) is not doing a great job and slow. 

Fixed the bug of k-opt heuristic for regular 2-sided permutation (f7958c3) and now everything seems good.