### PR TITLE
Refactor returns of Procrustes methods with an object

### DIFF
--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -23,7 +23,7 @@
 """Rotational-Orthogonal Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import error, setup_input_arrays
+from procrustes.utils import error, OptResult, setup_input_arrays
 
 
 def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
@@ -76,7 +76,7 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
         The transformed ndarray :math:`A`.
     new_b : ndarray
         The transformed ndarray :math:`B`.
-    u_opt : ndarray
+    array_u : ndarray
         The optimum rotation transformation matrix.
     e_opt : float
         One-sided orthogonal Procrustes error.
@@ -158,5 +158,5 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     u_opt = np.dot(np.dot(array_u, s_value), array_vt)
     # compute single-sided error error
     e_opt = error(new_a, new_b, u_opt)
-
-    return new_a, new_b, u_opt, e_opt
+    # returns the result object
+    return OptResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -155,8 +155,8 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     s_value = np.eye(new_a.shape[1])
     s_value[-1, -1] = np.sign(np.linalg.det(np.dot(array_u, array_vt)))
     # compute optimum rotation matrix
-    u_opt = np.dot(np.dot(array_u, s_value), array_vt)
+    array_u = np.dot(np.dot(array_u, s_value), array_vt)
     # compute single-sided error error
-    e_opt = error(new_a, new_b, u_opt)
-    # returns the result object
-    return OptResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)
+    e_opt = error(new_a, new_b, array_u)
+    # build the result object
+    return OptResult(new_a=new_a, new_b=new_b, array_u=array_u, e_opt=e_opt)

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -23,7 +23,7 @@
 """Rotational-Orthogonal Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import error, OptResult, setup_input_arrays
+from procrustes.utils import error, ProcrustesResult, setup_input_arrays
 
 
 def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
@@ -72,14 +72,14 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
 
     Returns
     -------
-    new_a : ndarray
-        The transformed ndarray :math:`A`.
-    new_b : ndarray
-        The transformed ndarray :math:`B`.
-    array_u : ndarray
-        The optimum rotation transformation matrix.
-    e_opt : float
-        One-sided orthogonal Procrustes error.
+    res : ProcrustesResult
+        The rotational Procrustes analysis result respresented as a ``ProcrustesResult`` object.
+        Important attributes inclue: ``new_a`` the transformed/scaled source array :math:`A`,
+        ``new_b`` the transformed/scaled target array :math:`B`, ``array_x`` the rightr-hand side of
+        the transformation array for single transformation problems, ``array_p`` the transformation
+        array for two-sided transformation Procrustes problems with one transformation array,
+        ``e_opt`` for the error or distance the two arrays after Procrustes operation. For other
+        attributes, please refer to `ProcrustesResult` for more details.
 
     Notes
     -----
@@ -134,14 +134,14 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     --------
     >>> import numpy as np
     >>> array_a = np.array([[1.5, 7.4], [8.5, 4.5]])
-    >>> array_b = np.array([[6.29325035,  4.17193001, 0., 0,], \
-                            [9.19238816, -2.82842712, 0., 0.], \
-                            [0.,          0.,         0., 0.]])
-    >>> new_a, new_b, array_u, e_opt = rotational(array_a, array_b, translate=False, scale=False)
-    >>> array_u # rotational array
+    >>> array_b = np.array([[6.29325035,  4.17193001, 0., 0,],
+    ...                     [9.19238816, -2.82842712, 0., 0.],
+    ...                     [0.,          0.,         0., 0.]])
+    >>> res = rotational(array_a, array_b, translate=False, scale=False)
+    >>> res['array_u'] # rotational array
     array([[ 0.70710678, -0.70710678],
            [ 0.70710678,  0.70710678]])
-    >>> e_opt # error
+    >>> res['e_opt'] # error
     1.483808210011695e-17
 
     """
@@ -159,4 +159,4 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     # compute single-sided error error
     e_opt = error(new_a, new_b, array_u)
     # build the result object
-    return OptResult(new_a=new_a, new_b=new_b, array_u=array_u, e_opt=e_opt)
+    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u, e_opt=e_opt)

--- a/procrustes/test/test_rotational.py
+++ b/procrustes/test/test_rotational.py
@@ -33,11 +33,11 @@ def test_rotational_orthogonal_identical():
     array_a = np.array([[3, 6, 2, 1], [5, 6, 7, 6], [2, 1, 1, 1]])
     array_b = np.copy(array_a)
     # compute Procrustes transformation
-    _, _, array_u, e_opt = rotational(array_a, array_b, translate=False, scale=False)
+    res = rotational(array_a, array_b, translate=False, scale=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(4), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(4), decimal=6)
+    assert_almost_equal(np.linalg.det(res["array_u"]), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_rotation_pad():
@@ -51,12 +51,11 @@ def test_rotational_orthogonal_rotation_pad():
     array_b = np.concatenate((array_b, np.zeros((2, 10))), axis=1)
     array_b = np.concatenate((array_b, np.zeros((15, 12))), axis=0)
     # compute procrustes transformation
-    _, _, array_u, e_opt = rotational(
-        array_a, array_b, translate=False, scale=False)
+    res = rotational(array_a, array_b, translate=False, scale=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(2), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(2), decimal=6)
+    assert_almost_equal(np.linalg.det(res["array_u"]), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_rotation_translate_scale():
@@ -70,11 +69,11 @@ def test_rotational_orthogonal_rotation_translate_scale():
                           [np.sin(theta), np.cos(theta), 0], [0, 0, 1]])
     array_b = np.dot(477.412 * array_a + shift, rot_array)
     # compute procrustes transformation
-    _, _, array_u, e_opt = rotational(array_a, array_b, translate=True, scale=True)
+    res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.linalg.det(res["array_u"]), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_rotation_translate_scale_4by3():
@@ -90,11 +89,11 @@ def test_rotational_orthogonal_rotation_translate_scale_4by3():
                           [np.sin(theta), np.cos(theta), 0], [0, 0, 1]])
     array_b = np.dot(12.54 * array_a + shift, rot_array)
     # compute procrustes transformation
-    _, _, array_u, e_opt = rotational(array_a, array_b, translate=True, scale=True)
+    res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.linalg.det(res["array_u"]), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_zero_array():
@@ -110,8 +109,8 @@ def test_rotational_orthogonal_zero_array():
                           [np.sin(theta), np.cos(theta), 0], [0, 0, 1]])
     array_b = np.dot(4.12 * array_a + shift, rot_array)
     # compute procrustes transformation
-    _, _, array_u, e_opt = rotational(array_a, array_b, translate=True, scale=True)
+    res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.linalg.det(res["array_u"]), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -367,6 +367,7 @@ class ProcrustesResult(dict):
     algorithm implementations. Since this class is essentially a subclass of dict with attribute
     accessors, one can see which attributes are available using the `keys()` method.
     """
+
     # modification on https://github.com/scipy/scipy/blob/v1.4.1/scipy/optimize/optimize.py#L77-L132
     def __getattr__(self, name):
         """Deal with attributes which it doesn't explicitly manage."""

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -382,8 +382,8 @@ class OptResult(dict):
     def __repr__(self):
         """Return a human friendly representation."""
         if self.keys():
-            m = max(map(len, list(self.keys()))) + 1
-            return '\n'.join([k.rjust(m) + ': ' + repr(v)
+            max_len = max(map(len, list(self.keys()))) + 1
+            return '\n'.join([k.rjust(max_len) + ': ' + repr(v)
                               for k, v in sorted(self.items())])
         else:
             return self.__class__.__name__ + "()"

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -38,7 +38,7 @@ Result : Returns the Procrustes analysis result which includes the translated/sc
 
 import numpy as np
 
-__all__ = ["error", "setup_input_arrays", "OptResult"]
+__all__ = ["error", "setup_input_arrays", "ProcrustesResult"]
 
 
 def _zero_padding(array_a, array_b, pad_mode="row-col"):
@@ -341,8 +341,8 @@ def _check_arraytypes(*args):
         raise TypeError("Matrix inputs must be 2-dimensional arrays")
 
 
-class OptResult(dict):
-    r"""Represents the Procrustes optimization result.
+class ProcrustesResult(dict):
+    r"""Represents the Procrustes analysis result.
 
     Attributes
     ----------
@@ -363,11 +363,10 @@ class OptResult(dict):
 
     Notes
     -----
-    Some of additional attributes are not listed above can be foundt at specific Procrustes
+    Some of additional attributes are not listed above can be found at specific Procrustes
     algorithm implementations. Since this class is essentially a subclass of dict with attribute
     accessors, one can see which attributes are available using the `keys()` method.
     """
-
     # modification on https://github.com/scipy/scipy/blob/v1.4.1/scipy/optimize/optimize.py#L77-L132
     def __getattr__(self, name):
         """Deal with attributes which it doesn't explicitly manage."""

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -361,11 +361,6 @@ class ProcrustesResult(dict):
     e_opt : float
         Two-sided permutation Procrustes error.
 
-    Notes
-    -----
-    Some of additional attributes are not listed above can be found at specific Procrustes
-    algorithm implementations. Since this class is essentially a subclass of dict with attribute
-    accessors, one can see which attributes are available using the `keys()` method.
     """
 
     # modification on https://github.com/scipy/scipy/blob/v1.4.1/scipy/optimize/optimize.py#L77-L132


### PR DESCRIPTION
Learned from `scipy.optimize`, https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html#scipy.optimize.minimize, it seems that using an object will help the usability of the package and we decided to change the returns of the implemented algorithms. Every function in the package will return an object and one can every attribute in the object conveniently,

```python
res = rotational(array_a, array_b)
# the rotation transformation matrix
res["array_u"]
# the distance error
res["e_opt"]
```

I have changed the codes in `procrustes.rotational` and seems to work nicely. If all the changes are OK, I am going to keep working on other functions.

- [x] Implentend the `OptResult` class, borrwed from https://github.com/scipy/scipy/blob/adc4f4f7bab120ccfab9383aba272954a0a12fb0/scipy/optimize/optimize.py#L77-L132 
 b1f6982
- [x] Fix `rotational` Procrustes and its test 53f9a01 and 8951455

