### PR TITLE
Doc

### DIFF
--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -169,10 +169,10 @@ def orthogonal_2sided(array_a, array_b, remove_zero_col=True, remove_zero_row=Tr
     array_b : ndarray
         The 2d-array :math:`\mathbf{B}_{m \times n}` representing the reference array.
     remove_zero_col : bool, optional
-        If True, the zero columns on the right side will be removed.
-        Default= True.
+        If True, zero columns (values less than 1e-8) on the right side will be removed.
+        Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the bottom will be removed.
+        If True, zero rows (values less than 1e-8) on the bottom will be removed.
         Default= True.
     pad_mode : str, optional
         Specifying how to pad the arrays, listed below. Default="row-col".

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -172,7 +172,7 @@ def orthogonal_2sided(array_a, array_b, remove_zero_col=True, remove_zero_row=Tr
         If True, the zero columns on the right side will be removed.
         Default= True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the top will be removed.
+        If True, the zero rows on the bottom will be removed.
         Default= True.
     pad_mode : str, optional
         Specifying how to pad the arrays, listed below. Default="row-col".

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -72,7 +72,8 @@ def orthogonal(array_a, array_b, remove_zero_col=True,
         will have mean zero.
         Default=False.
     scale : bool, optional
-        If True, both arrays are column normalized to unity.
+        If True, both arrays are normalized to one with respect to the Frobenius norm, ie
+        :math:`Tr(A^T A) = 1`.
         Default=False.
     check_finite : bool, optional
         If true, convert the input to an array, checking for NaNs or Infs.

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -68,7 +68,8 @@ def orthogonal(array_a, array_b, remove_zero_col=True,
                 squared arrays. The dimension of square array is specified based on the highest
                 dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
-        If True, both arrays are translated to be centered at origin.
+        If True, both arrays are translated to be centered at origin, ie columns of the arrays
+        will have mean zero.
         Default=False.
     scale : bool, optional
         If True, both arrays are column normalized to unity.

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -310,42 +310,7 @@ def orthogonal_2sided(array_a, array_b, remove_zero_col=True, remove_zero_row=Tr
         0        &\cdots   &0      &{ \pm 1}
        \end{bmatrix}
 
-    Finding the best choice of :math:`\mathbf{S}` requires :math:`2^n` trial-and-error tests.
-    This is called the ``exact`` scheme for solving the probelm.
-
-    A heuristic, due to Umeyama, is to take the element-wise absolute value of the elements
-    of the unitary transformations,
-
-    .. math::
-       \mathbf{U}_\text{Umeyama} = \text{abs}(\mathbf{U}_A) \cdot \text{abs}(\mathbf{U}_B^\dagger)
-
-    This is not actually a unitary matrix. But we can use the orthogonal procrustes problem
-    to find the closest unitray matrix (i.e., the closest matrix that is unitarily equivalent
-    to the identity matrix),
-
-    .. math::
-       \underbrace{\min}_{\left\{\mathbf{U} | \mathbf{U}^{-1} = {\mathbf{U}}^\dagger \right\}}
-                          \|\mathbf{I}\mathbf{U} -  \mathbf{U}_\text{Umeyama}\|_{F}^2
-       &= \underbrace{\text{min}}_{\left\{\mathbf{U} | \mathbf{U}^{-1} = {\mathbf{U}}^\dagger
-                                   \right\}}
-          \text{Tr}\left[\left(\mathbf{U} - \mathbf{U}_\text{Umeyama} \right)^\dagger
-                         \left(\mathbf{U} - \mathbf{U}_\text{Umeyama} \right)\right] \\
-       &= \underbrace{\text{max}}_{\left\{\mathbf{U} | \mathbf{U}^{-1} = {\mathbf{U}}^\dagger
-                                   \right\}}
-          \text{Tr}\left[\mathbf{U}^\dagger \mathbf{U}_\text{Umeyama} \right]
-
-    considering the singular value decomposition of :math:`\mathbf{U}_\text{Umeyama}`,
-
-    .. math::
-       \mathbf{U}_\text{Umeyama} =
-            \tilde{\mathbf{U}} \tilde{\mathbf{\Sigma}} \tilde{\mathbf{V}}^\dagger
-
-    the solution is give by,
-
-    .. math::
-       \mathbf{U}_\text{Umeyama}^\text{approx} = \tilde{\mathbf{U}} \tilde{\mathbf{V}}^\dagger
-
-    This is called the ``approx`` scheme for solving the problem.
+    The matrix :math:`\mathbf{S}` is chosen to be the identity matrix.
 
     Please note that the translation operation is not well defined for two sided orthogonal
     procrustes since two sided rotation and translation don't commute. Therefore, please be careful

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -63,7 +63,9 @@ def permutation(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
         squared arrays. The dimension of square array is specified based on the highest dimension,
         i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`."
     translate : bool, optional
-        If True, both arrays are translated to be centered at origin. Default=False.
+        If True, both arrays are translated to be centered at origin, ie columns of the arrays
+        will have mean zero.
+        Default=False.
     scale : bool, optional
         If True, both arrays are column normalized to unity. Default=False.
     check_finite : bool, optional
@@ -174,7 +176,9 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
                 squared arrays. The dimension of square array is specified based on the highest
                 dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
-        If True, both arrays are translated to be centered at origin. Default=False.
+        If True, both arrays are translated to be centered at origin, ie columns of the arrays
+        will have mean zero.
+        Default=False.
     scale : bool, optional
         If True, both arrays are column normalized to unity. Default=False.
     mode : string, optional

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -154,7 +154,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
     remove_zero_col : bool, optional
         If True, the zero columns on the right side will be removed. Default= True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the top will be removed. Default= True.
+        If True, the zero rows on the bottom will be removed. Default= True.
     pad_mode : str, optional
         Specifying how to pad the arrays, listed below. Default="row-col".
 
@@ -692,7 +692,7 @@ def permutation_2sided_explicit(array_a, array_b,
         If True, the zero columns on the right side will be removed.
         Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the top will be removed. Default= True.
+        If True, the zero rows on the bottom will be removed. Default= True.
     pad_mode : str, optional
         Zero padding mode when the sizes of two arrays differ. Default="row-col".
         "row": The array with fewer rows is padded with zero rows so that both have the same number

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -152,9 +152,10 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         two-sided permutation Procrustes with two transformations will be performed.
         Default="single_undirected".
     remove_zero_col : bool, optional
-        If True, the zero columns on the right side will be removed. Default= True.
+        If True, zero columns (values less than 1e-8) on the right side will be removed.
+        Default= True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the bottom will be removed. Default= True.
+        If True, zero rows (values less than 1e-8) on the bottom will be removed. Default= True.
     pad_mode : str, optional
         Specifying how to pad the arrays, listed below. Default="row-col".
 
@@ -689,10 +690,10 @@ def permutation_2sided_explicit(array_a, array_b,
     array_b : ndarray
         The 2d-array :math:`\mathbf{B}_{m \times n}` representing the reference.
     remove_zero_col : bool, optional
-        If True, the zero columns on the right side will be removed.
+        If True, near zero columns (less than 1e-8) on the right side will be removed.
         Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the bottom will be removed. Default= True.
+        If True, near zero rows (less than 1e-8) on the bottom will be removed. Default= True.
     pad_mode : str, optional
         Zero padding mode when the sizes of two arrays differ. Default="row-col".
         "row": The array with fewer rows is padded with zero rows so that both have the same number

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -67,7 +67,9 @@ def permutation(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
         will have mean zero.
         Default=False.
     scale : bool, optional
-        If True, both arrays are column normalized to unity. Default=False.
+        If True, both arrays are normalized to one with respect to the Frobenius norm, ie
+        :math:`Tr(A^T A) = 1`.
+        Default=False.
     check_finite : bool, optional
         If true, convert the input to an array, checking for NaNs or Infs. Default=True.
 
@@ -180,7 +182,9 @@ def permutation_2sided(array_a, array_b, transform_mode="single_undirected",
         will have mean zero.
         Default=False.
     scale : bool, optional
-        If True, both arrays are column normalized to unity. Default=False.
+        If True, both arrays are normalized to one with respect to the Frobenius norm, ie
+        :math:`Tr(A^T A) = 1`.
+        Default=False.
     mode : string, optional
         Option for choosing the initial guess methods, including "normal1",
         "normal2", "umeyama" and "umeyama_approx". "umeyama_approx" is the

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -51,17 +51,22 @@ def permutation(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     remove_zero_row : bool, optional
         If True, the zero rows on the top will be removed. Default= True.
     pad_mode : str, optional
-        Zero padding mode when the sizes of two arrays differ. Default="row-col".
-        "row": The array with fewer rows is padded with zero rows so that both have the same number
-        of rows.
-        "col": The array with fewer columns is padded with zero columns so that both have the
-        same number of columns.
-        "row-col": The array with fewer rows is padded with zero rows, and the array with fewer
-        columns is padded with zero columns, so that both have the same dimensions.
-        This does not necessarily result in square arrays.
-        "square": The arrays are padded with zero rows and zero columns so that they are both
-        squared arrays. The dimension of square array is specified based on the highest dimension,
-        i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`."
+        Specifying how to pad the arrays, listed below. Default="row-col".
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin, ie columns of the arrays
         will have mean zero.
@@ -703,17 +708,22 @@ def permutation_2sided_explicit(array_a, array_b,
     remove_zero_row : bool, optional
         If True, near zero rows (less than 1e-8) on the bottom will be removed. Default= True.
     pad_mode : str, optional
-        Zero padding mode when the sizes of two arrays differ. Default="row-col".
-        "row": The array with fewer rows is padded with zero rows so that both have the same number
-        of rows.
-        "col": The array with fewer columns is padded with zero columns so that both have the
-        same number of columns.
-        "row-col": The array with fewer rows is padded with zero rows, and the array with fewer
-        columns is padded with zero columns, so that both have the same dimensions.
-        This does not necessarily result in square arrays.
-        "square": The arrays are padded with zero rows and zero columns so that they are both
-        squared arrays. The dimension of square array is specified based on the highest dimension,
-        i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`."
+        Specifying how to pad the arrays, listed below. Default="row-col".
+
+            - "row"
+                The array with fewer rows is padded with zero rows so that both have the same
+                number of rows.
+            - "col"
+                The array with fewer columns is padded with zero columns so that both have the
+                same number of columns.
+            - "row-col"
+                The array with fewer rows is padded with zero rows, and the array with fewer
+                columns is padded with zero columns, so that both have the same dimensions.
+                This does not necessarily result in square arrays.
+            - "square"
+                The arrays are padded with zero rows and zero columns so that they are both
+                squared arrays. The dimension of square array is specified based on the highest
+                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin. Default=False.
     scale : bool, optional

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -44,7 +44,7 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
         If True, the zero columns on the right side will be removed.
         Default= True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the top will be removed.
+        If True, the zero rows on the bottom will be removed.
         Default= True.
     pad_mode : str, optional
         Specifying how to pad the arrays, listed below. Default="row-col".

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -64,7 +64,9 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
                 squared arrays. The dimension of square array is specified based on the highest
                 dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
-        If True, both arrays are translated to be centered at origin.
+        If True, both arrays are translated to be centered at origin, ie columns of the arrays
+        will have mean zero.
+        Default=False.
     scale : bool, optional
         If True, both arrays are column normalized to unity.
     check_finite : bool, optional

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -41,10 +41,10 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     array_b : ndarray
         The 2d-array :math:`\mathbf{B}_{m \times n}` representing the reference array.
     remove_zero_col : bool, optional
-        If True, the zero columns on the right side will be removed.
+        If True, zero columns (values less than 1e-8) on the right side will be removed.
         Default= True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the bottom will be removed.
+        If True, zero rows (values less than 1e-8) on the bottom will be removed.
         Default= True.
     pad_mode : str, optional
         Specifying how to pad the arrays, listed below. Default="row-col".

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -68,7 +68,9 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
         will have mean zero.
         Default=False.
     scale : bool, optional
-        If True, both arrays are column normalized to unity.
+        If True, both arrays are normalized to one with respect to the Frobenius norm, ie
+        :math:`Tr(A^T A) = 1`.
+        Default=False.
     check_finite : bool, optional
         If true, convert the input to an array, checking for NaNs or Infs.
 

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -104,7 +104,9 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
         will have mean zero.
         Default=False.
     scale : bool, optional
-        If True, both arrays are column normalized to unity. Default=False.
+        If True, both arrays are normalized to one with respect to the Frobenius norm, ie
+        :math:`Tr(A^T A) = 1`.
+        Default=False.
     check_finite : bool, optional
         If true, convert the input to an array, checking for NaNs or Infs. Default=True.
     adapted : bool, optional

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -100,7 +100,8 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
         If True, zero rows (values less than 1e-8) on the bottom will be removed.
         Default=True.
     translate : bool, optional
-        If True, both arrays are translated to be centered at origin.
+        If True, both arrays are translated to be centered at origin, ie columns of the arrays
+        will have mean zero.
         Default=False.
     scale : bool, optional
         If True, both arrays are column normalized to unity. Default=False.

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -97,7 +97,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
         If True, the zero columns on the right side will be removed.
         Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the top will be removed.
+        If True, the zero rows on the bottom will be removed.
         Default=True.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin.

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -94,10 +94,10 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
                 squared arrays. The dimension of square array is specified based on the highest
                 dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     remove_zero_col : bool, optional
-        If True, the zero columns on the right side will be removed.
+        If True, zero columns (values less than 1e-8) on the right side will be removed.
         Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the bottom will be removed.
+        If True, zero rows (values less than 1e-8) on the bottom will be removed.
         Default=True.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin.

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -42,10 +42,10 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     array_b : ndarray
         The 2d-array :math:`\mathbf{B}_{m \times n}` representing the reference.
     remove_zero_col : bool, optional
-        If True, the zero columns on the right side will be removed.
+        If True, zero columns (values less than 1e-8) on the right side will be removed.
         Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the bottom will be removed.
+        If True, zero rows (values less than 1e-8) on the bottom will be removed.
         Default=True.
     pad_mode : str, optional
         Specifying how to pad the arrays, listed below. Default="row-col".

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -66,9 +66,12 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
                 dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin, ie columns of the arrays
-        will have mean zero.  Default=False.
+        will have mean zero.
+        Default=False.
     scale : bool, optional
-        If True, both arrays are column normalized to unity. Default=False.
+        If True, both arrays are normalized to one with respect to the Frobenius norm, ie
+        :math:`Tr(A^T A) = 1`.
+        Default=False.
     check_finite : bool, optional
         If true, convert the input to an array, checking for NaNs or Infs.
         Default=True.

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -45,7 +45,7 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
         If True, the zero columns on the right side will be removed.
         Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the top will be removed.
+        If True, the zero rows on the bottom will be removed.
         Default=True.
     pad_mode : str, optional
         Specifying how to pad the arrays, listed below. Default="row-col".

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -65,8 +65,8 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
                 squared arrays. The dimension of square array is specified based on the highest
                 dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
-        If True, both arrays are translated to be centered at origin.
-        Default=False.
+        If True, both arrays are translated to be centered at origin, ie columns of the arrays
+        will have mean zero.  Default=False.
     scale : bool, optional
         If True, both arrays are column normalized to unity. Default=False.
     check_finite : bool, optional

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -161,6 +161,7 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     # check inputs
     new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
                                       pad_mode, translate, scale, check_finite)
+
     if new_a.shape[0] < new_a.shape[1]:
         raise ValueError("Array A with size (m, n) needs m >= to n.")
     if new_b.shape[0] < new_b.shape[1]:
@@ -170,11 +171,7 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     array_n = new_a.shape[1]
     array_u, array_s, array_vt = np.linalg.svd(new_a)
 
-    # add zeros to the eigenvalue array so it has length n
-    if len(array_s) < new_a.shape[1]:
-        array_s = np.concatenate((array_s, np.zeros(array_n - len(array_s))))
     array_c = np.dot(np.dot(array_u.T, new_b), array_vt.T)
-
     # create the intermediate array Y and the optimum symmetric transformation array X
     array_y = np.zeros((array_n, array_n))
     for i in range(array_n):

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -189,7 +189,7 @@ def _hide_zero_padding(array_a, remove_zero_col=True, remove_zero_row=True, tol=
     remove_zero_col : bool, optional
         If True, the zero columns on the right side will be removed. Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the top will be removed. Default=True.
+        If True, the zero rows on the bottom will be removed. Default=True.
     tol : float
         Tolerance value.
 
@@ -283,7 +283,7 @@ def setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
     remove_zero_col : bool, optional
         If True, the zero columns on the right side will be removed. Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the top will be removed. Default=True.
+        If True, the zero rows on the bottom will be removed. Default=True.
     pad_mode : str
         Specifying how to pad the arrays. Should be one of
 

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -187,9 +187,11 @@ def _hide_zero_padding(array_a, remove_zero_col=True, remove_zero_row=True, tol=
     array_a : ndarray
         The initial array.
     remove_zero_col : bool, optional
-        If True, the zero columns on the right side will be removed. Default=True.
+        If True, zero columns (values less than 1e-8) on the right side will be removed.
+        Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the bottom will be removed. Default=True.
+        If True, zero rows (values less than 1e-8) on the bottom will be removed.
+        Default=True.
     tol : float
         Tolerance value.
 
@@ -281,9 +283,10 @@ def setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
     array_b : npdarray
         The 2D reference array :math:`B`.
     remove_zero_col : bool, optional
-        If True, the zero columns on the right side will be removed. Default=True.
+        If True, zero columns (values less than 1e-8) on the right side will be removed.
+        Default=True.
     remove_zero_row : bool, optional
-        If True, the zero rows on the bottom will be removed. Default=True.
+        If True, zero rows (values less than 1e-8) on the bottom will be removed. Default=True.
     pad_mode : str
         Specifying how to pad the arrays. Should be one of
 

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -122,6 +122,8 @@ def _translate_array(array_a, array_b=None):
     """
     Return translated array_a and translation vector.
 
+    Columns of both arrays will have mean zero.
+
     Parameters
     ----------
     array_a : ndarray
@@ -305,7 +307,8 @@ def setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
                 squared arrays. The dimension of square array is specified based on the highest
                 dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool
-        If true, then translate both arrays :math:`A, B` to the origin.
+        If true, then translate both arrays :math:`A, B` to the origin, ie columns of the arrays
+        will have mean zero.
     scale :
         If true, then both arrays :math:`A, B` are scaled/normalized.
     check_finite : bool

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -152,7 +152,7 @@ def _translate_array(array_a, array_b=None):
 
 def _scale_array(array_a, array_b=None):
     """
-    Return scaled array_a and scaling vector.
+    Return scaled/normalized array_a and scaling vector.
 
     Parameters
     ----------
@@ -164,8 +164,7 @@ def _scale_array(array_a, array_b=None):
     Returns
     -------
     scaled_a, ndarray
-        If array_b is None, array_a is scaled to match norm of unit sphere using array_a"s
-        Frobenius norm.
+        If array_b is None, array_a is normalized using the Frobenius norm.
         If array_b is given, array_a is scaled to match array_b"s norm (the norm of array_a
         will be equal norm of array_b).
     scale : float
@@ -310,7 +309,8 @@ def setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
         If true, then translate both arrays :math:`A, B` to the origin, ie columns of the arrays
         will have mean zero.
     scale :
-        If true, then both arrays :math:`A, B` are scaled/normalized.
+        If True, both arrays are normalized to one with respect to the Frobenius norm, ie
+        :math:`Tr(A^T A) = 1`.
     check_finite : bool
         If true, then checks if both arrays :math:`A, B` are numpy arrays and two-dimensional.
 


### PR DESCRIPTION
This pull request is regarding function documentation in most files.

Changes to Doc
----------------------
- Typo in argument `remove_zero_row` - Change top to bottom (0eec9e0)
- Add that rows/columns whose values are all less than 1e8 are removed rather than saying zero (b52db1c).
- Removed umeyama doc in orthogonal.py and replaced it by saying that S-matrix is chosen to be the identity (4d9c862),
I still need to push my other branch for this to make sense with the code but did it anyways.
- I wasn't sure what a translated array is, so I wrote it out more specifically (d3e6f54).
- The argument  `scale` does not normalize the columns  (see `utils.py`) and is fixed by saying that it normalized with respect to Frobenius norm (496b57f).

Other Changes
---------------------
In the process of improving code coverage for symmetric.py.
- Added a test in the case when the matrix A has zero singular values (6d8fd20).    
- Removed the if-state in the symmetric.py algorithm. The reasoning is that the matrices are restricted to (m <= n), as done in Higham's paper and hence it will always have n singular values.  np.linalg.svd will always return an array of n values (the singular values) hence the if statement is never satisfied (8165322).
