### PR TITLE
Better returns

### DIFF
--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -23,7 +23,7 @@
 """Rotational-Orthogonal Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import error, setup_input_arrays
+from procrustes.utils import error, ProcrustesResult, setup_input_arrays
 
 
 def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
@@ -141,11 +141,11 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     >>> array_b = np.array([[6.29325035,  4.17193001, 0., 0,],
     ...                     [9.19238816, -2.82842712, 0., 0.],
     ...                     [0.,          0.,         0., 0.]])
-    >>> new_a, new_b, array_u, e_opt = rotational(array_a, array_b, translate=False, scale=False)
-    >>> array_u # rotational array
+    >>> res = rotational(array_a, array_b, translate=False, scale=False)
+    >>> res['array_u'] # rotational array
     array([[ 0.70710678, -0.70710678],
            [ 0.70710678,  0.70710678]])
-    >>> e_opt # error
+    >>> res['e_opt'] # error
     1.483808210011695e-17
 
     """
@@ -163,4 +163,4 @@ def rotational(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     # compute single-sided error error
     e_opt = error(new_a, new_b, u_opt)
 
-    return new_a, new_b, u_opt, e_opt
+    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u, e_opt=e_opt)

--- a/procrustes/test/test_rotational.py
+++ b/procrustes/test/test_rotational.py
@@ -33,11 +33,11 @@ def test_rotational_orthogonal_identical():
     array_a = np.array([[3, 6, 2, 1], [5, 6, 7, 6], [2, 1, 1, 1]])
     array_b = np.copy(array_a)
     # compute Procrustes transformation
-    _, _, array_u, e_opt = rotational(array_a, array_b, translate=False, scale=False)
+    res = rotational(array_a, array_b, translate=False, scale=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(4), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(4), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_rotation_pad():
@@ -51,12 +51,11 @@ def test_rotational_orthogonal_rotation_pad():
     array_b = np.concatenate((array_b, np.zeros((2, 10))), axis=1)
     array_b = np.concatenate((array_b, np.zeros((15, 12))), axis=0)
     # compute procrustes transformation
-    _, _, array_u, e_opt = rotational(
-        array_a, array_b, translate=False, scale=False)
+    res = rotational(array_a, array_b, translate=False, scale=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(2), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(2), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_rotation_translate_scale():
@@ -70,11 +69,11 @@ def test_rotational_orthogonal_rotation_translate_scale():
                           [np.sin(theta), np.cos(theta), 0], [0, 0, 1]])
     array_b = np.dot(477.412 * array_a + shift, rot_array)
     # compute procrustes transformation
-    _, _, array_u, e_opt = rotational(array_a, array_b, translate=True, scale=True)
+    res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_rotation_translate_scale_4by3():
@@ -90,11 +89,11 @@ def test_rotational_orthogonal_rotation_translate_scale_4by3():
                           [np.sin(theta), np.cos(theta), 0], [0, 0, 1]])
     array_b = np.dot(12.54 * array_a + shift, rot_array)
     # compute procrustes transformation
-    _, _, array_u, e_opt = rotational(array_a, array_b, translate=True, scale=True)
+    res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_zero_array():
@@ -110,8 +109,8 @@ def test_rotational_orthogonal_zero_array():
                           [np.sin(theta), np.cos(theta), 0], [0, 0, 1]])
     array_b = np.dot(4.12 * array_a + shift, rot_array)
     # compute procrustes transformation
-    _, _, array_u, e_opt = rotational(array_a, array_b, translate=True, scale=True)
+    res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(array_u, array_u.T), np.eye(3), decimal=6)
-    assert_almost_equal(np.linalg.det(array_u), 1.0, decimal=6)
-    assert_almost_equal(e_opt, 0, decimal=6)
+    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(res["e_opt"], 0, decimal=6)

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -493,6 +493,7 @@ class ProcrustesResult(dict):
         Two-sided permutation Procrustes error.
 
     """
+
     # modification on https://github.com/scipy/scipy/blob/v1.4.1/scipy/optimize/optimize.py#L77-L132
     def __getattr__(self, name):
         """Deal with attributes which it doesn't explicitly manage."""


### PR DESCRIPTION
Learned from scipy.optimize, https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html#scipy.optimize.minimize, it seems that using an object will help the usability of the package and we decided to change the returns of the implemented algorithms. Every function in the package will return an object and one can every attribute in the object conveniently,

```python
res = rotational(array_a, array_b)
# the rotation transformation matrix
res["array_u"]
# the distance error
res["e_opt"]
```

I have changed the codes in procrustes.rotational and seems to work nicely. If all the changes are OK, I am going to keep working on other functions.

This PR is similar to #14, but with a cleaner git history.
