### PR TITLE
Refactor orthogonal.py

### DIFF
--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -22,7 +22,6 @@
 # --
 """Orthogonal Procrustes Module."""
 
-from itertools import product
 import warnings
 
 import numpy as np

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -388,7 +388,6 @@ def orthogonal_2sided(array_a, array_b,
     else:
         u_opt1, u_opt2 = _2sided(new_a, new_b)
         e_opt = error(new_a, new_b, u_opt1, u_opt2)
-        # return new_a, new_b, u_opt1, u_opt2, e_opt
         return ProcrustesResult(new_a=new_a, new_b=new_b,
                                 array_p=u_opt1, array_q=u_opt2, e_opt=e_opt)
 

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -382,7 +382,6 @@ def orthogonal_2sided(array_a, array_b,
         _, array_ub = np.linalg.eigh(new_b)
         u_opt = array_ua.dot(array_ub.T)
         
-        # the error
         e_opt = error(new_a, new_b, u_opt, u_opt)
         return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)
     # Do regular two-sided orthogonal Procrustes calculations

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -377,11 +377,10 @@ def orthogonal_2sided(array_a, array_b,
 
     # Do single-transformation computation if requested
     if single_transform:
-        # check array_a and array_b are symmetric.  #FIXME : They are no checks here.
         _, array_ua = np.linalg.eigh(new_a)
         _, array_ub = np.linalg.eigh(new_b)
         u_opt = array_ua.dot(array_ub.T)
-        
+
         e_opt = error(new_a, new_b, u_opt, u_opt)
         return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)
     # Do regular two-sided orthogonal Procrustes calculations

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -256,11 +256,6 @@ def orthogonal_2sided(array_a, array_b,
     ------
     ValueError
         When input array :math:`A` or :math:`A` is not symmetric.
-    numpy.linalg.LinAlgError
-        If array :math:`A` or :math:`A` is not diagonalizable when `mode='umeyama'` or
-        `mode='umeyama_approx'`.
-    ValueError
-        If the mode is not 'exact' or 'approx' when `single_transform=True`.
 
     Notes
     -----

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -403,17 +403,3 @@ def _2sided(array_a, array_b):
     u_opt1 = np.dot(array_ua, array_ub.T)
     u_opt2 = np.dot(vta.T, vtb)
     return u_opt1, u_opt2
-
-
-def _2sided_1trans_approx(array_a, array_b, tol):
-    # Calculate the eigenvalue decomposition of array_a and array_b
-    _, array_ua = np.linalg.eigh(array_a)
-    _, array_ub = np.linalg.eigh(array_b)
-    # compute u_umeyama
-    u_umeyama = np.dot(np.abs(array_ua), np.abs(array_ub.T))
-    # compute the closet unitary transformation to u_umeyama
-    array_identity = np.eye(u_umeyama.shape[0], dtype=u_umeyama.dtype)
-    res = orthogonal(array_identity, u_umeyama)
-    u_ortho = res["array_u"]
-    u_ortho[np.abs(u_ortho) < tol] = 0
-    return u_ortho

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -26,7 +26,11 @@ from itertools import product
 import warnings
 
 import numpy as np
+<<<<<<< HEAD
 from procrustes.utils import error, ProcrustesResult, setup_input_arrays
+=======
+from procrustes.utils import error, setup_input_arrays, ProcrustesResult
+>>>>>>> Remove else statement and comment for brevity
 
 __all__ = [
     "orthogonal",
@@ -380,11 +384,10 @@ def orthogonal_2sided(array_a, array_b,
         e_opt = error(new_a, new_b, u_opt, u_opt)
         return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)
     # Do regular two-sided orthogonal Procrustes calculations
-    else:
-        u_opt1, u_opt2 = _2sided(new_a, new_b)
-        e_opt = error(new_a, new_b, u_opt1, u_opt2)
-        return ProcrustesResult(new_a=new_a, new_b=new_b,
-                                array_p=u_opt1, array_q=u_opt2, e_opt=e_opt)
+    u_opt1, u_opt2 = _2sided(new_a, new_b)
+    e_opt = error(new_a, new_b, u_opt1, u_opt2)
+    return ProcrustesResult(new_a=new_a, new_b=new_b,
+                            array_p=u_opt1, array_q=u_opt2, e_opt=e_opt)
 
 
 def _2sided(array_a, array_b):

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -177,10 +177,15 @@ def orthogonal(array_a, array_b,
     return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u_opt, e_opt=e_opt)
 
 
-def orthogonal_2sided(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
-                      pad_mode='row-col', translate=False, scale=False,
-                      single_transform=True, mode="exact", check_finite=True,
-                      tol=1.0e-8, weight=None):
+def orthogonal_2sided(array_a, array_b,
+                      remove_zero_col=True,
+                      remove_zero_row=True,
+                      pad_mode='row-col',
+                      translate=False,
+                      scale=False,
+                      single_transform=True,
+                      check_finite=True,
+                      weight=None):
     r"""
     Two-Sided Orthogonal Procrustes.
 
@@ -221,14 +226,9 @@ def orthogonal_2sided(array_a, array_b, remove_zero_col=True, remove_zero_row=Tr
     single_transform : bool
         If True, two-sided orthogonal Procrustes with one transformation
         will be performed. Default=False.
-    mode : string, optional
-        The scheme to solve for unitary transformation.
-        Options: 'exact' and 'approx'. Default="exact".
     check_finite : bool, optional
         If true, convert the input to an array, checking for NaNs or Infs.
         Default=True.
-    tol : float, optional
-        The tolerance value used for 'approx' mode. Default=1.e-8.
     weight : ndarray
         The weighting matrix. Default=None.
 
@@ -373,18 +373,15 @@ def orthogonal_2sided(array_a, array_b, remove_zero_col=True, remove_zero_row=Tr
                 Two sided rotation and translation don't commute.", stacklevel=2)
     # Check inputs
     new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                      pad_mode, translate, scale, check_finite, weight)
-    # Convert mode strings into lowercase
-    mode = mode.lower()
+                                          pad_mode, translate, scale, check_finite, weight)
+
     # Do single-transformation computation if requested
     if single_transform:
         # check array_a and array_b are symmetric.  #FIXME : They are no checks here.
-        if mode == "approx":
-            u_opt = _2sided_1trans_approx(new_a, new_b, tol)
-        elif mode == "exact":
-            u_opt = _2sided_1trans_exact(new_a, new_b)
-        else:
-            raise ValueError("Invalid mode argument (use 'exact' or 'approx')")
+        _, array_ua = np.linalg.eigh(new_a)
+        _, array_ub = np.linalg.eigh(new_b)
+        u_opt = array_ua.dot(array_ub.T)
+        
         # the error
         e_opt = error(new_a, new_b, u_opt, u_opt)
         return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -26,11 +26,7 @@ from itertools import product
 import warnings
 
 import numpy as np
-<<<<<<< HEAD
 from procrustes.utils import error, ProcrustesResult, setup_input_arrays
-=======
-from procrustes.utils import error, setup_input_arrays, ProcrustesResult
->>>>>>> Remove else statement and comment for brevity
 
 __all__ = [
     "orthogonal",

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -362,18 +362,19 @@ def orthogonal_2sided(array_a, array_b,
     1.9646186414076689e-26
 
     """
-    # Check symmetry if single_transform=True
-    if single_transform:
-        if not np.allclose(array_a.T, array_a):
-            raise ValueError("array_a should be symmetric.")
-        if not np.allclose(array_b.T, array_b):
-            raise ValueError("array_b should be symmetric.")
     if translate:
         warnings.warn("The translation matrix was not well defined. \
                 Two sided rotation and translation don't commute.", stacklevel=2)
     # Check inputs
     new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                          pad_mode, translate, scale, check_finite, weight)
+                                      pad_mode, translate, scale, check_finite, weight)
+
+    # Check symmetry if single_transform=True
+    if single_transform:
+        if not np.allclose(new_a.T, new_a):
+            raise ValueError("array_a, after removal/padding, should be symmetric.")
+        if not np.allclose(new_b.T, new_b):
+            raise ValueError("array_b, after removal/padding, should be symmetric.")
 
     # Do single-transformation computation if requested
     if single_transform:

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -417,25 +417,3 @@ def _2sided_1trans_approx(array_a, array_b, tol):
     u_ortho = res["array_u"]
     u_ortho[np.abs(u_ortho) < tol] = 0
     return u_ortho
-
-
-def _2sided_1trans_exact(array_a, array_b):
-    _, array_ua = np.linalg.eigh(array_a)
-    _, array_ub = np.linalg.eigh(array_b)
-    # 2^n trial-and-error test to find optimum S array
-    diags = product((-1, 1.), repeat=array_a.shape[0])
-
-    error_list = []
-    diag_list = []
-    for _, diag in enumerate(diags):
-        array_s = np.diag(diag)
-        array_u = np.dot(np.dot(array_ua, array_s), array_ub.T)
-        e_temp = error(array_a, array_b, array_u, array_u)
-        error_list.append(e_temp)
-        diag_list.append(array_s)
-
-    index = np.argmin(error_list)
-    s_opt = diag_list[index]
-    u_opt = np.dot(np.dot(array_ua, s_opt), array_ub.T)
-
-    return u_opt

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -242,6 +242,29 @@ def test_two_sided_orthogonal_identical():
     assert_almost_equal(result["e_opt"], 0., decimal=6)
 
 
+def test_two_sided_orthogonal_raises_error_non_symmetric_matrices():
+    r"""Test that 2-sided orthogonal procrustes non-symmetric matrices return an error."""
+    # Test simple example with one matrix that is not square
+    array_a = np.array([[1., 2., 3.], [1., 2., 3.]])
+    array_b = np.array([[1., 2.], [2., 1.]])
+    assert_raises(ValueError, orthogonal_2sided, array_a, array_b, single_transform=True)
+    assert_raises(ValueError, orthogonal_2sided, array_b, array_a, single_transform=True)
+
+    # Test one which is square but not symmetric.
+    array_a = np.array([[1., 1.], [2., 2.]])
+    array_b = np.array([[1., 2.], [2., 1.]])
+    assert_raises(ValueError, orthogonal_2sided, array_a, array_b, single_transform=True)
+    assert_raises(ValueError, orthogonal_2sided, array_b, array_a, single_transform=True)
+
+    # Test one that works but removal of rows with bad padding gives an error.
+    array_a = np.array([[1., 0.], [0., 0.]])
+    array_b = np.array([[1., 2.], [2., 1.]])
+    assert_raises(ValueError, orthogonal_2sided, array_a, array_b, single_transform=True,
+                  remove_zero_col=True, pad_mode="row")
+    assert_raises(ValueError, orthogonal_2sided, array_b, array_a, single_transform=True,
+                  remove_zero_col=True, pad_mode="col")
+
+
 def test_two_sided_orthogonal_rotate_reflect():
     r"""Test 2sided orthogonal by 3by3 array with rotation and reflection."""
     # define an arbitrary array
@@ -405,6 +428,7 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
     assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(2), decimal=8)
     assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
     assert_almost_equal(result["e_opt"], 0, decimal=8)
+
 
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
     r"""Test 2sided orthogonal by 3by3 array with single translation, scling and rotation."""

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -358,9 +358,9 @@ def test_two_sided_orthogonal_single_transformation_rot_reflect_padded():
 
     # check transformation array and error.
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
-    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
-    assert_almost_equal(result[3], 0, decimal=8)
+    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    assert_almost_equal(result["e_opt"], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_3by3():
@@ -380,9 +380,9 @@ def test_two_sided_orthogonal_single_transformation_scale_3by3():
     # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
                                single_transform=True)
-    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
-    assert_almost_equal(result[3], 0, decimal=8)
+    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    assert_almost_equal(result["e_opt"], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
@@ -402,9 +402,9 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
     # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
                                single_transform=True)
-    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(2), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
-    assert_almost_equal(result[3], 0, decimal=8)
+    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(2), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    assert_almost_equal(result["e_opt"], 0, decimal=8)
 
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
     r"""Test 2sided orthogonal by 3by3 array with single translation, scling and rotation."""
@@ -423,9 +423,9 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
     # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
                                single_transform=True)
-    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
-    assert_almost_equal(result[3], 0, decimal=8)
+    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    assert_almost_equal(result["e_opt"], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_random_orthogonal():
@@ -440,6 +440,6 @@ def test_two_sided_orthogonal_single_transformation_random_orthogonal():
     array_b = np.dot(np.dot(ortho.T, array_a), ortho)
     # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
-    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
-    assert_almost_equal(result[3], 0, decimal=8)
+    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(4), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    assert_almost_equal(result["e_opt"], 0, decimal=8)

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -325,34 +325,14 @@ def test_two_sided_orthogonal_translate_scale_rotate_reflect_3by3():
     assert_almost_equal(result["e_opt"], 0, decimal=6)
 
 
-def test_two_sided_orthogonal_single_transformation_invalid_mode_argument():
-    r"""Test 2sided orthogonal with invalid argument for single_transform."""
-    # define a random matrix
-    array_a = np.array([[0, 5, 8, 6], [-5, 0, 5, 1],
-                        [8, 5, 0, 2], [6, 1, 2, 0]])
-    array_b = np.array([[0, 1, 8, 4], [1, 0, 5, 2],
-                        [8, 5, 0, 5], [4, 2, 5, 0]])
-    # check invalid arguments
-    assert_raises(ValueError, orthogonal_2sided, array_a, array_b, single_transform=True)
-
-
 def test_two_sided_orthogonal_single_transformation_identical():
     r"""Test 2sided orthogonal with identical arrays."""
     # define an arbitrary symmetric array
     array_a = np.array([[2, 5, 4, 1], [5, 3, 1, 2], [8, 9, 1, 0], [1, 5, 6, 7]])
     array_a = np.dot(array_a, array_a.T)
     array_b = np.copy(array_a)
-    # test the "exact" mode
-    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="exact")
-    # check transformation array and error
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(4), decimal=8)
-    # the rotations might not be unique
-    # assert_almost_equal(abs(array_u), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
-    # test the "approx" mode
-    result = orthogonal_2sided(array_a, array_b, translate=False, scale=False,
-                               single_transform=True, mode="approx")
+
+    result = orthogonal_2sided(array_a, array_b, single_transform=True)
     # check transformation array and error
     assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(4), decimal=8)
     assert_almost_equal(abs(result["array_u"]), np.eye(4), decimal=8)
@@ -376,15 +356,11 @@ def test_two_sided_orthogonal_single_transformation_rot_reflect_padded():
     array_b = np.concatenate((array_b, np.zeros((3, 5))), axis=1)
     array_b = np.concatenate((array_b, np.zeros((5, 8))), axis=0)
 
-    # check transformation array and error of "exact" mode
-    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="exact")
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
-    # check transformation array and error of "approx" mode
-    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="approx")
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    # check transformation array and error.
+    result = orthogonal_2sided(array_a, array_b, single_transform=True)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_3by3():
@@ -401,18 +377,12 @@ def test_two_sided_orthogonal_single_transformation_scale_3by3():
     # define array_b by transforming scaled-and-translated array_a
     array_b = np.dot(np.dot(trans.T, 6.9 * array_a), trans)
 
-    # check transformation array and error of "exact" mode
+    # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
-                               single_transform=True, mode="exact")
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
-    # check transformation array and error of "approx" mode
-    result = orthogonal_2sided(array_a, array_b, translate=True, scale=True,
-                               single_transform=True, mode="approx")
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    # error: 2.1162061737807796
+                               single_transform=True)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
@@ -429,18 +399,12 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
     # define array_b by transforming scaled array_a
     array_b = np.dot(np.dot(trans.T, 88.89 * array_a), trans)
 
-    # check transformation array and error of "exact" mode
+    # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
-                               single_transform=True, mode="exact")
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(2), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
-
-    # check transformation array and error of "approx" mode
-    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="approx")
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(2), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-
+                               single_transform=True)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(2), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
 
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
     r"""Test 2sided orthogonal by 3by3 array with single translation, scling and rotation."""
@@ -456,20 +420,16 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
     # define array_b by transforming scaled array_a
     array_b = np.dot(np.dot(trans.T, 6.9 * array_a), trans)
 
-    # check transformation array and error of "exact" mode
+    # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
-                               single_transform=True, mode="exact")
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
-    # check transformation array and error of "approx" mode
-    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="approx")
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+                               single_transform=True)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_random_orthogonal():
-    r"""Test 2sided orthogonal by 3by3 array with exact method."""
+    r"""Test 2sided orthogonal by 3by3 array."""
     # define random array
     array_a = np.array([[0, 5, 8, 6], [5, 0, 5, 1],
                         [8, 5, 0, 2], [6, 1, 2, 0]])
@@ -478,8 +438,8 @@ def test_two_sided_orthogonal_single_transformation_random_orthogonal():
                       [1, 0, 0, 0],
                       [0, 1, 0, 0]])
     array_b = np.dot(np.dot(ortho.T, array_a), ortho)
-    # check transformation array and error of "exact" mode
-    result = orthogonal_2sided(array_a, array_b, single_transform=True, mode="exact")
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
+    # check transformation array and error
+    result = orthogonal_2sided(array_a, array_b, single_transform=True)
+    assert_almost_equal(np.dot(result[2], result[2].T), np.eye(4), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result[2])), 1.0, decimal=8)
+    assert_almost_equal(result[3], 0, decimal=8)


### PR DESCRIPTION
This pull request is regarding refactoring orthogonal.py, in particular the two-side orthogonal Procrustes problem.

Most of these commits were due to my mistakes in rebasing and not being careful, so I apologize.
Two sided orthogonal Procruste problem does not require optimizing the "S" matrix in the documentation/paper.
So the "approximate" and "exact" modes are not needed anymore, (5fc65db,  e4b3f8f ). Consequently, the tests that involve these two modes were removed (e9b9d86, b75ac49). Its errors in the documentation were removed (53f94db ).

I also cleaned it up a bit by removing an else statement, removing some not needed comments.
Since two-sided Procruste problem requires symmetric matrices as input, I added these as tests in three simple cases (179f109 )