### PR TITLE
Change ProcrustesResult argument e_opt to error

### DIFF
--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -23,7 +23,7 @@
 """Generic Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import error, ProcrustesResult, setup_input_arrays
+from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
 
 
 def generic(array_a, array_b,
@@ -123,5 +123,5 @@ def generic(array_a, array_b,
     # compute the generic solution
     a_inv = np.linalg.pinv(np.dot(new_a.T, new_a))
     array_x = np.linalg.multi_dot([a_inv, new_a.T, new_b])
-    e_opt = error(new_a, new_b, array_x)
+    e_opt = compute_error(new_a, new_b, array_x)
     return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_x, e_opt=e_opt)

--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -93,7 +93,7 @@ def generic(array_a, array_b,
         The transformed ndarray array_b.
     array_u : ndarray
         The optimum symmetric transformation array.
-    e_opt : float
+    error : float
         One-sided Procrustes error.
 
     Notes
@@ -124,4 +124,4 @@ def generic(array_a, array_b,
     a_inv = np.linalg.pinv(np.dot(new_a.T, new_a))
     array_x = np.linalg.multi_dot([a_inv, new_a.T, new_b])
     e_opt = compute_error(new_a, new_b, array_x)
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_x, e_opt=e_opt)
+    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_x, error=e_opt)

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -103,7 +103,7 @@ def orthogonal(array_a, array_b,
         The transformed ndarray :math:`B`.
     array_u : ndarray
         The optimum orthogonal transformation matrix.
-    e_opt : float
+    error : float
         One-sided orthogonal Procrustes error.
 
     Notes
@@ -171,9 +171,9 @@ def orthogonal(array_a, array_b,
     # compute optimum orthogonal transformation
     array_u_opt = np.dot(array_u, array_vt)
     # compute the error
-    e_opt = compute_error(new_a, new_b, array_u_opt)
-    # return new_a, new_b, array_u_opt, e_opt
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u_opt, e_opt=e_opt)
+    error = compute_error(new_a, new_b, array_u_opt)
+    # return new_a, new_b, array_u_opt, error
+    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u_opt, error=error)
 
 
 def orthogonal_2sided(array_a, array_b,
@@ -248,7 +248,7 @@ def orthogonal_2sided(array_a, array_b,
         The optimal orthogonal left-multiplying transformation ndarray if "single_transform=True".
     array_q : ndarray
         The second transformation ndarray if "single_transform=True".
-    e_opt : float
+    error : float
         The single- or double- sided orthogonal Procrustes error.
 
     Raises
@@ -376,13 +376,13 @@ def orthogonal_2sided(array_a, array_b,
         _, array_ub = np.linalg.eigh(new_b)
         u_opt = array_ua.dot(array_ub.T)
 
-        e_opt = compute_error(new_a, new_b, u_opt, u_opt)
-        return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)
+        error = compute_error(new_a, new_b, u_opt, u_opt)
+        return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, error=error)
     # Do regular two-sided orthogonal Procrustes calculations
     u_opt1, u_opt2 = _2sided(new_a, new_b)
-    e_opt = compute_error(new_a, new_b, u_opt1, u_opt2)
+    error = compute_error(new_a, new_b, u_opt1, u_opt2)
     return ProcrustesResult(new_a=new_a, new_b=new_b,
-                            array_p=u_opt1, array_q=u_opt2, e_opt=e_opt)
+                            array_p=u_opt1, array_q=u_opt2, error=error)
 
 
 def _2sided(array_a, array_b):

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -25,7 +25,6 @@
 import warnings
 
 import numpy as np
-
 from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
 
 __all__ = [

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -25,7 +25,8 @@
 import warnings
 
 import numpy as np
-from procrustes.utils import error, ProcrustesResult, setup_input_arrays
+
+from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
 
 __all__ = [
     "orthogonal",
@@ -171,7 +172,7 @@ def orthogonal(array_a, array_b,
     # compute optimum orthogonal transformation
     array_u_opt = np.dot(array_u, array_vt)
     # compute the error
-    e_opt = error(new_a, new_b, array_u_opt)
+    e_opt = compute_error(new_a, new_b, array_u_opt)
     # return new_a, new_b, array_u_opt, e_opt
     return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u_opt, e_opt=e_opt)
 
@@ -376,11 +377,11 @@ def orthogonal_2sided(array_a, array_b,
         _, array_ub = np.linalg.eigh(new_b)
         u_opt = array_ua.dot(array_ub.T)
 
-        e_opt = error(new_a, new_b, u_opt, u_opt)
+        e_opt = compute_error(new_a, new_b, u_opt, u_opt)
         return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)
     # Do regular two-sided orthogonal Procrustes calculations
     u_opt1, u_opt2 = _2sided(new_a, new_b)
-    e_opt = error(new_a, new_b, u_opt1, u_opt2)
+    e_opt = compute_error(new_a, new_b, u_opt1, u_opt2)
     return ProcrustesResult(new_a=new_a, new_b=new_b,
                             array_p=u_opt1, array_q=u_opt2, e_opt=e_opt)
 

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -25,7 +25,7 @@
 import itertools as it
 
 import numpy as np
-from procrustes.utils import (error, kopt_heuristic_double,
+from procrustes.utils import (compute_error, kopt_heuristic_double,
                               kopt_heuristic_single, ProcrustesResult, setup_input_arrays)
 from scipy.optimize import linear_sum_assignment
 
@@ -150,7 +150,7 @@ def permutation(array_a, array_b,
     array_u = np.zeros(array_p.shape)
     # set elements to 1 according to Hungarian algorithm (linear_sum_assignment)
     array_u[linear_sum_assignment(array_c)] = 1
-    e_opt = error(new_a, new_b, array_u)
+    e_opt = compute_error(new_a, new_b, array_u)
     # return new_a, new_b, array_u, e_opt
     return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u, e_opt=e_opt)
 
@@ -421,7 +421,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             # Compute the permutation matrix by iterations
             array_u = _compute_transform(new_a_positive, new_b_positive,
                                          guess, tol, iteration)
-            e_opt = error(new_a_positive, new_b_positive, array_u, array_u)
+            e_opt = compute_error(new_a_positive, new_b_positive, array_u, array_u)
             # k-opt heuristic
             if kopt:
                 array_u, e_opt = kopt_heuristic_single(array_u, new_a_positive,
@@ -434,7 +434,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             # Compute the permutation matrix by iterations
             array_u = _compute_transform_directed(new_a_positive, new_b_positive,
                                                   guess, tol, iteration)
-            e_opt = error(new_a_positive, new_b_positive, array_u, array_u)
+            e_opt = compute_error(new_a_positive, new_b_positive, array_u, array_u)
             # k-opt heuristic
             if kopt:
                 array_u, e_opt = kopt_heuristic_single(array_u, new_a_positive, new_b_positive,
@@ -474,7 +474,7 @@ def _2sided_regular(array_m, array_n, tol, iteration):
     array_p1 = np.eye(array_m.shape[0], array_m.shape[0])
     # Initial guess for Q
     array_q1 = _2sided_hungarian(np.dot(array_n.T, array_m))
-    e_opt1 = error(array_n, array_m, array_p1.T, array_q1)
+    e_opt1 = compute_error(array_n, array_m, array_p1.T, array_q1)
     step1 = 0
 
     # while loop for the original algorithm
@@ -484,12 +484,12 @@ def _2sided_regular(array_m, array_n, tol, iteration):
         array_p1 = _2sided_hungarian(np.dot(np.dot(array_n, array_q1), array_m.T))
         array_p1 = np.transpose(array_p1)
         # Update the error
-        e_opt1 = error(array_n, array_m, array_p1.T, array_q1)
+        e_opt1 = compute_error(array_n, array_m, array_p1.T, array_q1)
         if e_opt1 > tol:
             # Update Q
             array_q1 = _2sided_hungarian(np.dot(np.dot(array_n.T, array_p1.T), array_m))
             # Update the error
-            e_opt1 = error(array_n, array_m, array_p1.T, array_q1)
+            e_opt1 = compute_error(array_n, array_m, array_p1.T, array_q1)
         else:
             break
 
@@ -502,7 +502,7 @@ def _2sided_regular(array_m, array_n, tol, iteration):
     # Initial guess for P
     array_p2 = _2sided_hungarian(np.dot(array_n, array_m.T))
     array_p2 = np.transpose(array_p2)
-    e_opt2 = error(array_n, array_m, array_p2.T, array_q2)
+    e_opt2 = compute_error(array_n, array_m, array_p2.T, array_q2)
     step2 = 0
 
     # while loop for the original algorithm
@@ -510,12 +510,12 @@ def _2sided_regular(array_m, array_n, tol, iteration):
         # Update Q
         array_q2 = _2sided_hungarian(np.dot(np.dot(array_n.T, array_p2.T), array_m))
         # Update the error
-        e_opt2 = error(array_n, array_m, array_p2.T, array_q1)
+        e_opt2 = compute_error(array_n, array_m, array_p2.T, array_q1)
         if e_opt2 > tol:
             array_p2 = _2sided_hungarian(np.dot(np.dot(array_n, array_q2), array_m.T))
             array_p2 = np.transpose(array_p2)
             # Update the error
-            e_opt2 = error(array_n, array_m, array_p2.T, array_q2)
+            e_opt2 = compute_error(array_n, array_m, array_p2.T, array_q2)
             step2 += 1
         else:
             break
@@ -827,7 +827,7 @@ def permutation_2sided_explicit(array_a, array_b,
         size = np.shape(new_a)[1]
         perm2 = np.zeros((size, size))
         perm2[np.arange(size), comb] = 1
-        perm_error2 = error(new_a, new_b, perm2, perm2)
+        perm_error2 = compute_error(new_a, new_b, perm2, perm2)
         if perm_error2 < perm_error1:
             perm_error1 = perm_error2
             perm1 = perm2

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -95,7 +95,7 @@ def rotational(array_a, array_b,
         The transformed ndarray :math:`B`.
     array_u : ndarray
         The optimum rotational transformation matrix.
-    e_opt : float
+    error : float
         One-sided orthogonal Procrustes error.
 
     Notes
@@ -158,7 +158,7 @@ def rotational(array_a, array_b,
     >>> res['array_u'] # rotational array
     array([[ 0.70710678, -0.70710678],
            [ 0.70710678,  0.70710678]])
-    >>> res['e_opt'] # error
+    >>> res['error'] # error
     1.483808210011695e-17
 
     """
@@ -174,6 +174,6 @@ def rotational(array_a, array_b,
     # compute optimum rotation matrix
     u_opt = np.dot(np.dot(array_u, s_value), array_vt)
     # compute single-sided error error
-    e_opt = compute_error(new_a, new_b, u_opt)
+    error = compute_error(new_a, new_b, u_opt)
 
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)
+    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, error=error)

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -23,7 +23,7 @@
 """Rotational-Orthogonal Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import error, ProcrustesResult, setup_input_arrays
+from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
 
 
 def rotational(array_a, array_b,
@@ -174,6 +174,6 @@ def rotational(array_a, array_b,
     # compute optimum rotation matrix
     u_opt = np.dot(np.dot(array_u, s_value), array_vt)
     # compute single-sided error error
-    e_opt = error(new_a, new_b, u_opt)
+    e_opt = compute_error(new_a, new_b, u_opt)
 
     return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, e_opt=e_opt)

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -136,7 +136,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
         The transformed ndarray B.
     array_u : ndarray
         The optimum permutation transformation matrix.
-    e_opt : float
+    error : float
         Two-sided Procrustes error.
 
     Notes
@@ -187,7 +187,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
     ...                  [0., 0., 0., 1.], [0., 1., 0., 0.]])
         # define array_b by permuting array_a
     >>> array_b = np.dot(perm.T, np.dot(array_a, perm))
-    >>> new_a, new_b, M_ai, e_opt = softassign(array_a, array_b,
+    >>> new_a, new_b, M_ai, error = softassign(array_a, array_b,
     ...                                        remove_zero_col=False,
     ...                                        remove_zero_row=False)
     >>> M_ai # the permutation matrix
@@ -195,7 +195,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
            [1., 0., 0., 0.],
            [0., 0., 0., 1.],
            [0., 1., 0., 0.]])
-    >>> e_opt # the error
+    >>> error # the error
     0.0
 
     """
@@ -307,8 +307,8 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
 
     # Compute the error
     array_m = permutation(np.eye(array_m.shape[0]), array_m)["array_u"]
-    e_opt = compute_error(new_a, new_b, array_m, array_m)
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_m, e_opt=e_opt)
+    error = compute_error(new_a, new_b, array_m, array_m)
+    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_m, error=error)
 
 
 def _compute_gamma(array_c, row_num, gamma_scaler):

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -27,7 +27,7 @@ import warnings
 
 import numpy as np
 from procrustes.permutation import permutation
-from procrustes.utils import error, ProcrustesResult, setup_input_arrays
+from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
 
 __all__ = [
     "softassign",
@@ -307,7 +307,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
 
     # Compute the error
     array_m = permutation(np.eye(array_m.shape[0]), array_m)["array_u"]
-    e_opt = error(new_a, new_b, array_m, array_m)
+    e_opt = compute_error(new_a, new_b, array_m, array_m)
     return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_m, e_opt=e_opt)
 
 

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -92,7 +92,7 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
         The transformed ndarray array_b.
     array_u : ndarray
         The optimum symmetric transformation array.
-    e_opt : float
+    error : float
         One-sided Procrustes error.
 
     Raises
@@ -191,6 +191,6 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
                 array_y[i, j] = (array_s[i] * array_c[i, j] + array_s[j] * array_c[j, i]) / (
                             array_s[i] ** 2 + array_s[j] ** 2)
     array_x = np.dot(np.dot(array_vt.T, array_y), array_vt)
-    e_opt = compute_error(new_a, new_b, array_x)
+    error = compute_error(new_a, new_b, array_x)
 
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_x, e_opt=e_opt)
+    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_x, error=error)

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -23,7 +23,7 @@
 """Symmetric Procrustes Module."""
 
 import numpy as np
-from procrustes.utils import error, ProcrustesResult, setup_input_arrays
+from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
 
 
 def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
@@ -191,6 +191,6 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
                 array_y[i, j] = (array_s[i] * array_c[i, j] + array_s[j] * array_c[j, i]) / (
                             array_s[i] ** 2 + array_s[j] ** 2)
     array_x = np.dot(np.dot(array_vt.T, array_y), array_vt)
-    e_opt = error(new_a, new_b, array_x)
+    e_opt = compute_error(new_a, new_b, array_x)
 
     return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_x, e_opt=e_opt)

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -44,7 +44,7 @@ def test_generic_transformed():
     res = generic(array_a, array_b, translate=False, scale=False)
     # check transformation is right & error is zero
     assert_almost_equal(res["array_u"], array_x, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_generic_transformed_negative():
@@ -61,7 +61,7 @@ def test_generic_transformed_negative():
     res = generic(array_a, array_b, translate=False, scale=False)
     # check transformation is right & error is zero
     assert_almost_equal(res["array_u"], array_x, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_generic_transformed_translate():
@@ -78,7 +78,7 @@ def test_generic_transformed_translate():
     res = generic(array_a, array_b, translate=True, scale=False)
     # check transformation is right & error is zero
     assert_almost_equal(res["array_u"], array_x, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_generic_transformed_scale():
@@ -94,7 +94,7 @@ def test_generic_transformed_scale():
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=False, scale=True)
     # check transformation is right & error is zero
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_generic_transformed_translate_scale():
@@ -110,7 +110,7 @@ def test_generic_transformed_translate_scale():
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=True, scale=True)
     # check transformation is error is zero
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_generic_random_transformation():
@@ -124,4 +124,4 @@ def test_generic_random_transformation():
     res = generic(array_a, array_b, translate=False, scale=False)
     # check transformation is right & error is zero
     assert_almost_equal(res["array_u"], array_x, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -239,7 +239,7 @@ def test_two_sided_orthogonal_identical():
     assert_almost_equal(np.linalg.det(result["array_q"]), 1.0, decimal=6)
     assert_almost_equal(result["array_p"], np.eye(4), decimal=6)
     assert_almost_equal(result["array_q"], np.eye(4), decimal=6)
-    assert_almost_equal(result["e_opt"], 0., decimal=6)
+    assert_almost_equal(result["error"], 0., decimal=6)
 
 
 def test_two_sided_orthogonal_raises_error_non_symmetric_matrices():
@@ -282,7 +282,7 @@ def test_two_sided_orthogonal_rotate_reflect():
     assert_almost_equal(np.abs(np.linalg.det(result["array_p"])), 1.0, decimal=6)
     assert_almost_equal(np.abs(np.linalg.det(result["array_q"])), 1.0, decimal=6)
     # transformation should return zero error
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_two_sided_orthogonal_rotate_reflect_pad():
@@ -304,7 +304,7 @@ def test_two_sided_orthogonal_rotate_reflect_pad():
     assert_almost_equal(np.dot(result["array_q"], result["array_q"].T), np.eye(2), decimal=6)
     assert_almost_equal(abs(np.linalg.det(result["array_p"])), 1.0, decimal=6)
     assert_almost_equal(abs(np.linalg.det(result["array_q"])), 1.0, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_two_sided_orthogonal_translate_scale_rotate_reflect():
@@ -325,7 +325,7 @@ def test_two_sided_orthogonal_translate_scale_rotate_reflect():
     assert_almost_equal(abs(np.linalg.det(result["array_p"])), 1.0, decimal=6)
     assert_almost_equal(abs(np.linalg.det(result["array_q"])), 1.0, decimal=6)
     # transformation should return zero error
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_two_sided_orthogonal_translate_scale_rotate_reflect_3by3():
@@ -345,7 +345,7 @@ def test_two_sided_orthogonal_translate_scale_rotate_reflect_3by3():
     assert_almost_equal(np.dot(result["array_q"], result["array_q"].T), np.eye(3), decimal=6)
     assert_almost_equal(abs(np.linalg.det(result["array_p"])), 1.0, decimal=6)
     assert_almost_equal(abs(np.linalg.det(result["array_q"])), 1.0, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_two_sided_orthogonal_single_transformation_identical():
@@ -360,7 +360,7 @@ def test_two_sided_orthogonal_single_transformation_identical():
     assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(4), decimal=8)
     assert_almost_equal(abs(result["array_u"]), np.eye(4), decimal=8)
     assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
+    assert_almost_equal(result["error"], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_rot_reflect_padded():
@@ -383,7 +383,7 @@ def test_two_sided_orthogonal_single_transformation_rot_reflect_padded():
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
     assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
     assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
+    assert_almost_equal(result["error"], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_3by3():
@@ -405,7 +405,7 @@ def test_two_sided_orthogonal_single_transformation_scale_3by3():
                                single_transform=True)
     assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
     assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
+    assert_almost_equal(result["error"], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
@@ -427,7 +427,7 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
                                single_transform=True)
     assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(2), decimal=8)
     assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
+    assert_almost_equal(result["error"], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
@@ -449,7 +449,7 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
                                single_transform=True)
     assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
     assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
+    assert_almost_equal(result["error"], 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_random_orthogonal():
@@ -466,4 +466,4 @@ def test_two_sided_orthogonal_single_transformation_random_orthogonal():
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
     assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(4), decimal=8)
     assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
-    assert_almost_equal(result["e_opt"], 0, decimal=8)
+    assert_almost_equal(result["error"], 0, decimal=8)

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -25,7 +25,7 @@ r"""Testings for orthogonal Procrustes module."""
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 from procrustes.orthogonal import orthogonal, orthogonal_2sided
-from procrustes.utils import error
+from procrustes.utils import compute_error
 
 
 def make_rotation_array(theta):
@@ -45,7 +45,7 @@ def test_procrustes_orthogonal_identical():
     # check transformation array is identity
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # case of identical rectangular arrays (2 by 4)
     array_a = np.array([[1, 5, 6, 7], [1, 2, 9, 4]])
     array_b = np.copy(array_a)
@@ -54,7 +54,7 @@ def test_procrustes_orthogonal_identical():
     assert_almost_equal(res["new_b"], array_b, decimal=6)
     assert_equal(res["array_u"].shape, (4, 4))
     # assert_almost_equal(array_u, np.eye(4), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # case of identical rectangular arrays (5 by 3)
     array_a = np.arange(15).reshape(5, 3)
     array_b = np.copy(array_a)
@@ -62,7 +62,7 @@ def test_procrustes_orthogonal_identical():
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
     assert_equal(res["array_u"].shape, (3, 3))
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
 
 
 def test_procrustes_rotation_square():
@@ -73,37 +73,37 @@ def test_procrustes_rotation_square():
     array_b = np.array([[1, 0], [3, -2]])
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["array_u"], np.array([[0., -1.], [1., 0.]]), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # rotation by 180 degree
     array_b = -array_a
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["array_u"], np.array([[-1., 0.], [0., -1.]]), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # rotation by 270 degree
     array_b = np.array([[-1, 0], [-3, 2]])
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["array_u"], np.array([[0., 1.], [-1., 0.]]), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # rotation by 45 degree
     rotation = 0.5 * np.sqrt(2) * np.array([[1, -1], [1, 1]])
     array_b = np.dot(array_a, rotation)
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["array_u"], rotation, decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # rotation by 30 degree
     theta = np.pi / 6
     rotation = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
     array_b = np.dot(array_a, rotation)
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["array_u"], rotation, decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # rotation by 72 degree
     theta = 1.25664
     rotation = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
     array_b = np.dot(array_a, rotation)
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["array_u"], rotation, decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
 
 
 def test_procrustes_reflection_square():
@@ -116,22 +116,22 @@ def test_procrustes_reflection_square():
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
     assert_almost_equal(res["array_u"], np.array([[-1, 0], [0, -1]]), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # reflection in the x-axis
     array_b = np.array([[2.0, -0.1], [0.5, -3.0]])
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["array_u"], np.array([[1, 0], [0, -1]]), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # reflection in the y-axis
     array_b = np.array([[-2.0, 0.1], [-0.5, 3.0]])
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["array_u"], np.array([[-1, 0], [0, 1]]), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # reflection in the line y=x
     array_b = np.array([[0.1, 2.0], [3.0, 0.5]])
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["array_u"], np.array([[0, 1], [1, 0]]), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
 
 
 def test_procrustes_shifted():
@@ -144,13 +144,13 @@ def test_procrustes_shifted():
     res = orthogonal(array_a, array_b, translate=True)
     # assert_almost_equal(new_b, array_b, decimal=6)
     assert_almost_equal(res["array_u"], np.eye(3), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # different shift along each axis
     array_b = array_a + np.array([0, 3.2, 5.0])
     res = orthogonal(array_a, array_b, translate=True)
     # assert_almost_equal(new_b, array_b, decimal=6)
     assert_almost_equal(res["array_u"], np.eye(3), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # rectangular (2 by 3)
     array_a = np.array([[1, 2, 3], [7, 9, 5]])
     # expected_a = array_a - np.array([4., 5.5, 4.])
@@ -158,13 +158,13 @@ def test_procrustes_shifted():
     array_b = array_a + 0.71
     res = orthogonal(array_a, array_b, translate=True)
     # assert_almost_equal(new_b, array_b, decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # different shift along each axis
     array_b = array_a + np.array([0.3, 7.1, 4.2])
     res = orthogonal(array_a, array_b, translate=True)
     # assert_almost_equal(new_b, array_b, decimal=6)
     assert_equal(res["array_u"].shape, (3, 3))
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
 
 
 def test_procrustes_rotation_translation():
@@ -181,17 +181,17 @@ def test_procrustes_rotation_translation():
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
     assert_almost_equal(res["array_u"], np.dot(rotation, reflection), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # procrustes with translation
     res = orthogonal(array_a, array_b, translate=True)
     assert_almost_equal(res["new_a"], array_a - np.mean(array_a, axis=0), decimal=6)
     assert_almost_equal(res["new_b"], array_b - np.mean(array_b, axis=0), decimal=6)
     assert_almost_equal(res["array_u"], np.dot(rotation, reflection), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
     # procrustes with translation and scaling
     res = orthogonal(array_a, array_b, translate=True, scale=True)
     assert_almost_equal(res["array_u"], np.dot(rotation, reflection), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
 
 
 def test_rotation_translate_scale():
@@ -206,7 +206,7 @@ def test_rotation_translate_scale():
     # procrustes with translation and scaling
     res = orthogonal(array_a, array_b, translate=True, scale=True)
     assert_almost_equal(res["array_u"], np.dot(rotation, reflection), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
 
 
 def test_orthogonal_translate_scale2():
@@ -225,7 +225,7 @@ def test_orthogonal_translate_scale2():
     # compute procrustes transformation
     res = orthogonal(array_a, array_b, translate=False, scale=False)
     assert_almost_equal(res["array_u"], np.dot(rot, ref), decimal=6)
-    assert_almost_equal(error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
 
 
 def test_two_sided_orthogonal_identical():

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -45,7 +45,7 @@ def test_permutation_columns():
     # procrustes with no translate and scale
     res = permutation(array_a, array_b)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0., decimal=6)
+    assert_almost_equal(res["error"], 0., decimal=6)
 
 
 def test_permutation_columns_pad():
@@ -65,7 +65,7 @@ def test_permutation_columns_pad():
     assert_almost_equal(res["new_a"], array_a[:, :-1], decimal=6)
     assert_almost_equal(res["new_b"], array_b[:-1, :], decimal=6)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0., decimal=6)
+    assert_almost_equal(res["error"], 0., decimal=6)
 
 
 def test_permutation_translate_scale():
@@ -79,7 +79,7 @@ def test_permutation_translate_scale():
     # permutation procrustes
     res = permutation(array_a, array_b, translate=True, scale=True)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0., decimal=6)
+    assert_almost_equal(res["error"], 0., decimal=6)
 
 
 def test_permutation_translate_scale_padd():
@@ -97,7 +97,7 @@ def test_permutation_translate_scale_padd():
     # check
     res = permutation(array_a, array_b, translate=True, scale=True)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0., decimal=6)
+    assert_almost_equal(res["error"], 0., decimal=6)
 
 
 def test_2sided_1trans_initial_guess_normal1_positive():
@@ -222,7 +222,7 @@ def test_permutation_2sided_4by4_umeyama():
     # Check
     res = permutation_2sided(array_a, array_b, transform_mode="single", mode="umeyama")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_umeyama_loop():
@@ -239,7 +239,7 @@ def test_permutation_2sided_4by4_umeyama_loop():
         # Check
         res = permutation_2sided(array_a, array_b, transform_mode="single", mode="umeyama")
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_umeyama_loop_negative():
@@ -256,7 +256,7 @@ def test_permutation_2sided_4by4_umeyama_loop_negative():
         # Check
         res = permutation_2sided(array_a, array_b, transform_mode="single", mode="umeyama")
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_umeyama_translate_scale():
@@ -274,7 +274,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale():
     res = permutation_2sided(array_a, array_b, transform_mode="single",
                              translate=True, scale=True, mode="umeyama")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_umeyama_translate_scale_loop():
@@ -293,7 +293,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale_loop():
         res = permutation_2sided(array_a, array_b, transform_mode="single",
                                  translate=True, scale=True, mode="umeyama")
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_umeyama_translate_scale_zero_padding():
@@ -317,7 +317,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale_zero_padding():
     res = permutation_2sided(array_a, array_b, transform_mode="single",
                              translate=True, scale=True, mode="umeyama")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_umeyama_approx():
@@ -334,7 +334,7 @@ def test_permutation_2sided_4by4_umeyama_approx():
                              transform_mode="single",
                              mode="umeyama_approx")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_umeyama_approx_loop():
@@ -353,7 +353,7 @@ def test_permutation_2sided_4by4_umeyama_approx_loop():
                                  transform_mode="single",
                                  mode="umeyama_approx")
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_umeyama_approx_4by4_loop_negative():
@@ -372,7 +372,7 @@ def test_permutation_2sided_umeyama_approx_4by4_loop_negative():
                                  transform_mode="single",
                                  mode="umeyama_approx")
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_umeyama_approx_translate_scale():
@@ -390,7 +390,7 @@ def test_permutation_2sided_4by4_umeyama_approx_translate_scale():
     res = permutation_2sided(array_a, array_b, transform_mode="single",
                              translate=True, scale=True, mode="umeyama_approx")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_umeyama_approx_translate_scale_zero_padding():
@@ -412,7 +412,7 @@ def test_permutation_2sided_4by4_umeyama_approx_translate_scale_zero_padding():
     res = permutation_2sided(array_a, array_b, translate=True, scale=True,
                              transform_mode="single", mode="umeyama_approx")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal1():
@@ -426,7 +426,7 @@ def test_permutation_2sided_4by4_normal1():
     # Check
     res = permutation_2sided(array_a, array_b, transform_mode="single", mode="normal1")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal1_loop():
@@ -448,7 +448,7 @@ def test_permutation_2sided_4by4_normal1_loop():
                                      mode="normal1",
                                      iteration=700)
             assert_almost_equal(res["array_u"], perm, decimal=6)
-            assert_almost_equal(res["e_opt"], 0, decimal=6)
+            assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal1_loop_negative():
@@ -468,7 +468,7 @@ def test_permutation_2sided_4by4_normal1_loop_negative():
             res = permutation_2sided(array_a, array_b, transform_mode="single",
                                      translate=True, scale=True, mode="normal1")
             assert_almost_equal(res["array_u"], perm, decimal=6)
-            assert_almost_equal(res["e_opt"], 0, decimal=6)
+            assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal1_translate_scale():
@@ -484,7 +484,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale():
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal1")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal1_translate_scale_loop():
@@ -504,7 +504,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale_loop():
             array_a, array_b, transform_mode="single",
             translate=True, scale=True, mode="normal1")
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal1_translate_scale_zero_padding():
@@ -526,7 +526,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale_zero_padding():
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal1")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_normal1_practical_example():
@@ -552,7 +552,7 @@ def test_permutation_2sided_normal1_practical_example():
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal1")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal2():
@@ -567,7 +567,7 @@ def test_permutation_2sided_4by4_normal2():
     res = permutation_2sided(
         array_a, array_b, transform_mode="single", mode="normal2")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal2_loop():
@@ -587,7 +587,7 @@ def test_permutation_2sided_4by4_normal2_loop():
                 array_a, array_b, transform_mode="single",
                 translate=True, scale=True, mode="normal2")
             assert_almost_equal(res["array_u"], perm, decimal=6)
-            assert_almost_equal(res["e_opt"], 0, decimal=6)
+            assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal2_loop_negative():
@@ -607,7 +607,7 @@ def test_permutation_2sided_4by4_normal2_loop_negative():
                 array_a, array_b, transform_mode="single",
                 translate=True, scale=True, mode="normal2")
             assert_almost_equal(res["array_u"], perm, decimal=6)
-            assert_almost_equal(res["e_opt"], 0, decimal=6)
+            assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal2_translate_scale():
@@ -622,7 +622,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale():
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal2")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal2_translate_scale_loop():
@@ -641,7 +641,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale_loop():
             array_a, array_b, transform_mode="single",
             translate=True, scale=True, mode="normal2")
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_normal2_translate_scale_zero_padding():
@@ -662,7 +662,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale_zero_padding():
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal2")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_normal2_practical_example():
@@ -687,7 +687,7 @@ def test_permutation_2sided_normal2_practical_example():
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal2")
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_invalid_mode_argument():
@@ -732,7 +732,7 @@ def test_permutation_2sided_regular():
     result = permutation_2sided(array_m, array_n, transform_mode="double")
     assert_almost_equal(result["array_p"], array_p, decimal=6)
     assert_almost_equal(result["array_q"], array_q, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_regular2():
@@ -751,7 +751,7 @@ def test_permutation_2sided_regular2():
     result = permutation_2sided(array_m, array_n, transform_mode="double")
     assert_almost_equal(result["array_p"], array_p, decimal=6)
     assert_almost_equal(result["array_q"], array_q, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_regular_unsquared():
@@ -764,7 +764,7 @@ def test_permutation_2sided_regular_unsquared():
     result = permutation_2sided(array_m, array_n, transform_mode="double", iteration=500)
     assert_almost_equal(result["array_p"], perm_p, decimal=6)
     assert_almost_equal(result["array_q"], perm_q, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_regular_unsquared_negative():
@@ -779,7 +779,7 @@ def test_permutation_2sided_regular_unsquared_negative():
     result = permutation_2sided(array_m, array_n, transform_mode="double", iteration=500)
     assert_almost_equal(result["array_p"], perm_p, decimal=6)
     assert_almost_equal(result["array_q"], perm_q, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_directed():
@@ -793,7 +793,7 @@ def test_permutation_2sided_4by4_directed():
     # Procrustes with no translate and scale
     result = permutation_2sided(array_a, array_b, transform_mode="single")
     assert_almost_equal(result["array_u"], perm, decimal=6)
-    assert_almost_equal(result["e_opt"], 0., decimal=6)
+    assert_almost_equal(result["error"], 0., decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_symmetric():
@@ -807,7 +807,7 @@ def test_permutation_2sided_4by4_directed_symmetric():
     # Procrustes with no translate and scale
     result = permutation_2sided(array_a, array_b, transform_mode="single")
     assert_almost_equal(result["array_u"], perm, decimal=6)
-    assert_almost_equal(result["e_opt"], 0., decimal=6)
+    assert_almost_equal(result["error"], 0., decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_loop():
@@ -823,7 +823,7 @@ def test_permutation_2sided_4by4_directed_loop():
         # check
         result = permutation_2sided(array_a, array_b, transform_mode="single")
         assert_almost_equal(result["array_u"], perm, decimal=6)
-        assert_almost_equal(result["e_opt"], 0, decimal=6)
+        assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_netative_loop():
@@ -839,7 +839,7 @@ def test_permutation_2sided_4by4_directed_netative_loop():
         # check
         result = permutation_2sided(array_a, array_b, transform_mode="single")
         assert_almost_equal(result["array_u"], perm, decimal=6)
-        assert_almost_equal(result["e_opt"], 0, decimal=6)
+        assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_translate_scale():
@@ -856,7 +856,7 @@ def test_permutation_2sided_4by4_directed_translate_scale():
                                 transform_mode="single",
                                 translate=True, scale=True)
     assert_almost_equal(result["array_u"], perm, decimal=6)
-    assert_almost_equal(result["e_opt"], 0., decimal=6)
+    assert_almost_equal(result["error"], 0., decimal=6)
 
 
 def test_permutation_2sided_4by4_directed_translate_scale_padding():
@@ -878,7 +878,7 @@ def test_permutation_2sided_4by4_directed_translate_scale_padding():
                                 translate=True,
                                 scale=True)
     assert_almost_equal(result["array_u"], perm, decimal=6)
-    assert_almost_equal(result["e_opt"], 0., decimal=6)
+    assert_almost_equal(result["error"], 0., decimal=6)
 
 
 def test_permutation_2sided_explicit_4by4_loop():
@@ -895,7 +895,7 @@ def test_permutation_2sided_explicit_4by4_loop():
         # check
         result = permutation_2sided_explicit(array_a, array_b)
         assert_almost_equal(result["array_u"], perm, decimal=6)
-        assert_almost_equal(result["e_opt"], 0, decimal=6)
+        assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_explicit_4by4_loop_negative():
@@ -912,7 +912,7 @@ def test_permutation_2sided_explicit_4by4_loop_negative():
         # check
         result = permutation_2sided_explicit(array_a, array_b)
         assert_almost_equal(result["array_u"], perm, decimal=6)
-        assert_almost_equal(result["e_opt"], 0, decimal=6)
+        assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_explicit_4by4_translate_scale():
@@ -929,7 +929,7 @@ def test_permutation_2sided_explicit_4by4_translate_scale():
     # check
     result = permutation_2sided_explicit(array_a, array_b, translate=True, scale=True)
     assert_almost_equal(result["array_u"], perm, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_explicit_4by4_translate_scale_zero_padding():
@@ -950,7 +950,7 @@ def test_permutation_2sided_explicit_4by4_translate_scale_zero_padding():
     # check
     result = permutation_2sided_explicit(array_a, array_b, translate=True, scale=True)
     assert_almost_equal(result["array_u"], perm, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_invalid_transform_mode():
@@ -976,7 +976,7 @@ def test_permutation_2sided_add_noise_mode_umeyama():
     result = permutation_2sided(array_a, array_b, translate=False,
                                 scale=False, mode="umeyama", add_noise=True)
     assert_almost_equal(result["array_u"], perm, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_add_noise_mode_umeyama_approx():
@@ -990,7 +990,7 @@ def test_permutation_2sided_add_noise_mode_umeyama_approx():
     result = permutation_2sided(array_a, array_b, translate=False, scale=False,
                                 mode="umeyama_approx", add_noise=True)
     assert_almost_equal(result["array_u"], perm, decimal=6)
-    assert_almost_equal(result["e_opt"], 0, decimal=6)
+    assert_almost_equal(result["error"], 0, decimal=6)
 
 
 def test_permutation_2sided_dominators_zero():

--- a/procrustes/test/test_rotational.py
+++ b/procrustes/test/test_rotational.py
@@ -37,7 +37,7 @@ def test_rotational_orthogonal_identical():
     # check transformation array and error
     assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(4), decimal=6)
     assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_rotation_pad():
@@ -55,7 +55,7 @@ def test_rotational_orthogonal_rotation_pad():
     # check transformation array and error
     assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(2), decimal=6)
     assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_rotation_translate_scale():
@@ -73,7 +73,7 @@ def test_rotational_orthogonal_rotation_translate_scale():
     # check transformation array and error
     assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
     assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_rotation_translate_scale_4by3():
@@ -93,7 +93,7 @@ def test_rotational_orthogonal_rotation_translate_scale_4by3():
     # check transformation array and error
     assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
     assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_rotational_orthogonal_zero_array():
@@ -113,4 +113,4 @@ def test_rotational_orthogonal_zero_array():
     # check transformation array and error
     assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
     assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)

--- a/procrustes/test/test_softassign.py
+++ b/procrustes/test/test_softassign.py
@@ -43,7 +43,7 @@ def test_softassign_4by4():
                      remove_zero_col=False,
                      remove_zero_row=False)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_softassign_4by4_loop():
@@ -62,7 +62,7 @@ def test_softassign_4by4_loop():
                          remove_zero_col=False,
                          remove_zero_row=False)
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_softassign_4by4_loop_negative():
@@ -83,7 +83,7 @@ def test_softassign_4by4_loop_negative():
                              remove_zero_row=False,
                              remove_zero_col=False)
             assert_almost_equal(res["array_u"], perm, decimal=6)
-            assert_almost_equal(res["e_opt"], 0, decimal=6)
+            assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_softassign_4by4_translate_scale():
@@ -100,7 +100,7 @@ def test_softassign_4by4_translate_scale():
                      remove_zero_row=False,
                      remove_zero_col=False)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_softassign_4by4_translate_scale_loop():
@@ -121,7 +121,7 @@ def test_softassign_4by4_translate_scale_loop():
                          translate=True,
                          scale=True)
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_softassign_4by4_translate_scale_zero_padding():
@@ -144,7 +144,7 @@ def test_softassign_4by4_translate_scale_zero_padding():
                      remove_zero_row=True,
                      remove_zero_col=True)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_softassign_practical_example():
@@ -172,7 +172,7 @@ def test_softassign_practical_example():
                      remove_zero_row=False,
                      remove_zero_col=False)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_softassign_random_noise():
@@ -229,7 +229,7 @@ def test_softassign_4by4_beta_0():
                      translate=False,
                      scale=False)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_softassign_4by4_anneal_steps():
@@ -248,7 +248,7 @@ def test_softassign_4by4_anneal_steps():
                      translate=False,
                      scale=False)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
 
 
 def test_softassign_missing_iteration_anneal_beta_f():
@@ -286,7 +286,7 @@ def test_softassign_m_guess():
                      translate=False,
                      scale=False)
     assert_almost_equal(res["array_u"], perm, decimal=6)
-    assert_almost_equal(res["e_opt"], 0, decimal=6)
+    assert_almost_equal(res["error"], 0, decimal=6)
     # check if initial guess given shape not matching
     with warnings.catch_warnings(record=True) as warn_info:
         res = softassign(array_a,
@@ -299,4 +299,4 @@ def test_softassign_m_guess():
         assert not str(warn_info[0].message).startswith("We must specify")
         # check the results
         assert_almost_equal(res["array_u"], perm, decimal=6)
-        assert_almost_equal(res["e_opt"], 0, decimal=6)
+        assert_almost_equal(res["error"], 0, decimal=6)

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -48,7 +48,7 @@ def test_symmetric_transformed():
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
     assert_almost_equal(res["array_u"], sym_array, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_symmetric_scaled_shifted_tranformed():
@@ -64,7 +64,7 @@ def test_symmetric_scaled_shifted_tranformed():
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_symmetric_scaled_shifted_tranformed_4by3():
@@ -82,7 +82,7 @@ def test_symmetric_scaled_shifted_tranformed_4by3():
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_symmetric():
@@ -100,7 +100,7 @@ def test_symmetric():
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_not_full_rank_case():
@@ -113,7 +113,7 @@ def test_not_full_rank_case():
     res = symmetric(array_a, array_b)
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_having_zero_singular_case():
@@ -128,7 +128,7 @@ def test_having_zero_singular_case():
     res = symmetric(array_a, array_b)
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
-    assert_almost_equal(res["e_opt"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
 def test_fat_rectangular_matrices_raises_error_no_padding():
@@ -181,7 +181,7 @@ class TestAgainstNumerical:
         desired, desired_func = self._optimize(array_a, array_b, ncol)
         res = symmetric(array_a, array_b)
 
-        assert np.abs(res["e_opt"] - desired_func) < 1e-5
+        assert np.abs(res["error"] - desired_func) < 1e-5
         assert np.all(np.abs(res["array_u"] - desired) < 1e-3)
 
     @pytest.mark.parametrize("nrow", [2, 10, 15])
@@ -199,4 +199,4 @@ class TestAgainstNumerical:
         res = symmetric(array_a, array_b, pad_mode="square")
 
         # No uniqueness in solution, thus check that the optimal values are the same.
-        assert np.abs(res["e_opt"] - desired_func) < 1e-5
+        assert np.abs(res["error"] - desired_func) < 1e-5

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -404,14 +404,14 @@ def test_kopt_heuristic_double():
     perm2_shuff = np.array([[1., 0., 0.],
                             [0., 0., 1.],
                             [0., 1., 0.]])
-    e_opt = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
+    error = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
     perm_left, perm_right, kopt_error = kopt_heuristic_double(perm_p=perm1_shuff,
                                                               perm_q=perm2_shuff,
                                                               array_m=arr_a, array_n=arr_b,
-                                                              ref_error=e_opt, kopt_k=4,
+                                                              ref_error=error, kopt_k=4,
                                                               kopt_tol=1.e-8)
     _, _, kopt_error = kopt_heuristic_double(perm_p=perm_left, perm_q=perm_right,
                                              array_m=arr_a, array_n=arr_b,
-                                             ref_error=e_opt, kopt_k=3, kopt_tol=1.e-8)
-    assert kopt_error <= e_opt
+                                             ref_error=error, kopt_k=3, kopt_tol=1.e-8)
+    assert kopt_error <= error
     assert kopt_error == 0

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -25,7 +25,7 @@
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 from procrustes.utils import (_hide_zero_padding, _scale_array,
-                              _translate_array, _zero_padding, error,
+                              _translate_array, _zero_padding, compute_error,
                               kopt_heuristic_double, kopt_heuristic_single)
 
 
@@ -374,7 +374,7 @@ def test_kopt_heuristic_single():
                            [0, 0, 1, 0, 0],
                            [0, 0, 0, 0, 1],
                            [1, 0, 0, 0, 0]])
-    error_old = error(arr_a, arr_b, perm_guess, perm_guess)
+    error_old = compute_error(arr_a, arr_b, perm_guess, perm_guess)
     perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, error_old,
                                              perm_guess, 3, kopt_tol=1.e-8)
     assert_equal(perm, perm_exact)
@@ -404,7 +404,7 @@ def test_kopt_heuristic_double():
     perm2_shuff = np.array([[1., 0., 0.],
                             [0., 0., 1.],
                             [0., 1., 0.]])
-    e_opt = error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
+    e_opt = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
     perm_left, perm_right, kopt_error = kopt_heuristic_double(perm_p=perm1_shuff,
                                                               perm_q=perm2_shuff,
                                                               array_m=arr_a, array_n=arr_b,

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -22,8 +22,8 @@
 # --
 """Utility Module."""
 
-import itertools as it
 from copy import deepcopy
+import itertools as it
 
 import numpy as np
 

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -577,7 +577,7 @@ class ProcrustesResult(dict):
     array_q : ndarray
         The right hand side transformation matrix for two-sided Procrustes problem with
         two transformation.
-    e_opt : float
+    error : float
         Two-sided permutation Procrustes error.
 
     """

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -22,13 +22,13 @@
 # --
 """Utility Module."""
 
-from copy import deepcopy
 import itertools as it
+from copy import deepcopy
 
 import numpy as np
 
 __all__ = [
-    "error",
+    "compute_error",
     "setup_input_arrays",
     "kopt_heuristic_single",
     "kopt_heuristic_double",
@@ -233,7 +233,7 @@ def _hide_zero_padding(array_a, remove_zero_col=True, remove_zero_row=True, tol=
     return array_a
 
 
-def error(array_a, array_b, array_u, array_v=None):
+def compute_error(array_a, array_b, array_u, array_v=None):
     r"""
     Return the single- or double- sided Procrustes/norm-squared error.
 
@@ -470,7 +470,7 @@ def kopt_heuristic_single(array_a, array_b, ref_error, perm=None, kopt_k=3, kopt
             if comb_perm != comb:
                 perm_kopt = deepcopy(perm)
                 perm_kopt[comb, :] = perm_kopt[comb_perm, :]
-                e_kopt_new = error(array_a, array_b, perm_kopt, perm_kopt)
+                e_kopt_new = compute_error(array_a, array_b, perm_kopt, perm_kopt)
                 if e_kopt_new < kopt_error:
                     perm = perm_kopt
                     kopt_error = e_kopt_new
@@ -541,7 +541,8 @@ def kopt_heuristic_double(array_m, array_n, ref_error,
                         if comb_perm_right != comb_right:
                             perm_kopt_right = deepcopy(perm_q)
                             perm_kopt_right[comb_right, :] = perm_kopt_right[comb_perm_right, :]
-                            e_kopt_new_right = error(array_n, array_m, perm_p.T, perm_kopt_right)
+                            e_kopt_new_right = compute_error(array_n, array_m, perm_p.T,
+                                                             perm_kopt_right)
                             if e_kopt_new_right < kopt_error:
                                 perm_q = perm_kopt_right
                                 kopt_error = e_kopt_new_right
@@ -549,7 +550,7 @@ def kopt_heuristic_double(array_m, array_n, ref_error,
                                     break
 
                 perm_kopt_left[comb_left, :] = perm_kopt_left[comb_perm_left, :]
-                e_kopt_new_left = error(array_n, array_m, perm_kopt_left.T, perm_q)
+                e_kopt_new_left = compute_error(array_n, array_m, perm_kopt_left.T, perm_q)
                 if e_kopt_new_left < kopt_error:
                     perm_p = perm_kopt_left
                     kopt_error = e_kopt_new_left


### PR DESCRIPTION
This PR is mainly about to fixe issue #25.

Things addressed in the corresponding codes:
- [x] Rename `error()` to `compute_error()` in utils.py
- [x] Rename `e_opt` argument to `error` in `ProcrustesResult ` object
- [x] Fix all the corresponing testings

By doing so, we can get rid of potential ambiguity when people read the codes.