### PR TITLE
Isolate k-opt heristic functions as a separate module, Fixes #41

### DIFF
--- a/procrustes/__init__.py
+++ b/procrustes/__init__.py
@@ -24,6 +24,7 @@
 
 
 from procrustes.utils import *
+from procrustes.kopt import *
 from procrustes.orthogonal import *
 from procrustes.permutation import *
 from procrustes.rotational import *

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+# The Procrustes library provides a set of functions for transforming
+# a matrix to make it as similar as possible to a target matrix.
+#
+# Copyright (C) 2017-2020 The Procrustes Development Team
+#
+# This file is part of Procrustes.
+#
+# Procrustes is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# Procrustes is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Kopt Module."""
+
+from copy import deepcopy
+import itertools as it
+
+import numpy as np
+from procrustes.utils import compute_error
+
+__all__ = [
+    "kopt_heuristic_single",
+    "kopt_heuristic_double",
+]
+
+
+def kopt_heuristic_single(array_a, array_b, ref_error,
+                          perm=None, kopt_k=3, kopt_tol=1.e-8):
+    r"""K-opt heuristic to improve the accuracy for two-sided permutation with one transformation.
+
+    Perform k-opt local search with every possible valid combination of the swapping mechanism.
+
+    Parameters
+    ----------
+    array_a : ndarray
+        The array to be permuted.
+    array_b : ndarray
+        The reference array.
+    ref_error : float
+        The reference error value.
+    perm : ndarray, optional
+        The permutation array which remains to be processed with k-opt local search. Default is the
+        identity matrix with the same shape of array_a.
+    kopt_k : int, optional
+        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
+        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
+    kopt_tol : float, optional
+        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
+
+    Returns
+    -------
+    perm : ndarray
+        The permutation array after optimal heuristic search.
+    kopt_error : float
+        The error distance of two arrays with the updated permutation array.
+    """
+    if kopt_k < 2:
+        raise ValueError("Kopt_k value must be a integer greater than 2.")
+    # if perm is not specified, use the identity matrix as default
+    if perm is None:
+        perm = np.identity(np.shape(array_a)[0])
+    num_row = perm.shape[0]
+    kopt_error = ref_error
+    # all the possible row-wise permutations
+    for comb in it.combinations(np.arange(num_row), r=kopt_k):
+        for comb_perm in it.permutations(comb, r=kopt_k):
+            if comb_perm != comb:
+                perm_kopt = deepcopy(perm)
+                perm_kopt[comb, :] = perm_kopt[comb_perm, :]
+                e_kopt_new = compute_error(array_a, array_b, perm_kopt, perm_kopt)
+                if e_kopt_new < kopt_error:
+                    perm = perm_kopt
+                    kopt_error = e_kopt_new
+                    if kopt_error <= kopt_tol:
+                        break
+    return perm, kopt_error
+
+
+def kopt_heuristic_double(array_m, array_n, ref_error,
+                          perm_p=None, perm_q=None,
+                          kopt_k=3, kopt_tol=1.e-8):
+    r"""
+    K-opt kopt for regular two-sided permutation Procrustes to improve the accuracy.
+
+    Perform k-opt local search with every possible valid combination of the swapping mechanism for
+    regular 2-sided permutation Procrustes.
+
+    Parameters
+    ----------
+    array_m : ndarray
+        The array to be permuted.
+    array_n : ndarray
+        The reference array.
+    ref_error : float
+        The reference error value.
+    perm_p : ndarray, optional
+        The left permutation array which remains to be processed with k-opt local search. Default
+        is the identity matrix with the same shape of array_m.
+    perm_q : ndarray, optional
+        The right permutation array which remains to be processed with k-opt local search. Default
+        is the identity matrix with the same shape of array_m.
+    kopt_k : int, optional
+        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
+        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
+    kopt_tol : float, optional
+        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
+
+    Returns
+    -------
+    perm_kopt_p : ndarray
+        The left permutation array after optimal heuristic search.
+    perm_kopt_q : ndarray
+        The right permutation array after optimal heuristic search.
+    kopt_error : float
+        The error distance of two arrays with the updated permutation array.
+    """
+    if kopt_k < 2:
+        raise ValueError("Kopt_k value must be a integer greater than 2.")
+    # if perm_p is not specified, use the identity matrix as default
+    if perm_p is None:
+        perm_p = np.identity(np.shape(array_m)[0])
+    # if perm_p is not specified, use the identity matrix as default
+    if perm_q is None:
+        perm_q = np.identity(np.shape(array_m)[0])
+
+    num_row_left = perm_p.shape[0]
+    num_row_right = perm_q.shape[0]
+    kopt_error = ref_error
+    # the left hand side permutation
+    # pylint: disable=too-many-nested-blocks
+    for comb_left in it.combinations(np.arange(num_row_left), r=kopt_k):
+        for comb_perm_left in it.permutations(comb_left, r=kopt_k):
+            if comb_perm_left != comb_left:
+                perm_kopt_left = deepcopy(perm_p)
+                # the right hand side permutation
+                for comb_right in it.combinations(np.arange(num_row_right), r=kopt_k):
+                    for comb_perm_right in it.permutations(comb_right, r=kopt_k):
+                        if comb_perm_right != comb_right:
+                            perm_kopt_right = deepcopy(perm_q)
+                            perm_kopt_right[comb_right, :] = perm_kopt_right[comb_perm_right, :]
+                            e_kopt_new_right = compute_error(array_n, array_m, perm_p.T,
+                                                             perm_kopt_right)
+                            if e_kopt_new_right < kopt_error:
+                                perm_q = perm_kopt_right
+                                kopt_error = e_kopt_new_right
+                                if kopt_error <= kopt_tol:
+                                    break
+
+                perm_kopt_left[comb_left, :] = perm_kopt_left[comb_perm_left, :]
+                e_kopt_new_left = compute_error(array_n, array_m, perm_kopt_left.T, perm_q)
+                if e_kopt_new_left < kopt_error:
+                    perm_p = perm_kopt_left
+                    kopt_error = e_kopt_new_left
+                    if kopt_error <= kopt_tol:
+                        break
+
+    return perm_p, perm_q, kopt_error

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -434,9 +434,12 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
             # k-opt heuristic
             if kopt:
-                array_u, error = kopt_heuristic_single(array_u, new_a_positive,
-                                                       new_b_positive, error,
-                                                       kopt_k=kopt_k, kopt_tol=kopt_tol)
+                array_u, error = kopt_heuristic_single(array_a=new_a_positive,
+                                                       array_b=new_b_positive,
+                                                       ref_error=error,
+                                                       perm=array_u,
+                                                       kopt_k=kopt_k,
+                                                       kopt_tol=kopt_tol)
         # algorithm for directed graph matching problem
         else:
             # the initial guess
@@ -447,8 +450,12 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
             # k-opt heuristic
             if kopt:
-                array_u, error = kopt_heuristic_single(array_u, new_a_positive, new_b_positive,
-                                                       error, kopt_k=kopt_k, kopt_tol=kopt_tol)
+                array_u, error = kopt_heuristic_single(array_a=new_a_positive,
+                                                       array_b=new_b_positive,
+                                                       ref_error=error,
+                                                       perm=array_u,
+                                                       kopt_k=kopt_k,
+                                                       kopt_tol=kopt_tol)
         return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u, error=error)
 
     # Do regular computation
@@ -458,9 +465,12 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
         array_p, array_q, error = _2sided_regular(array_m, array_n, tol, iteration)
         # perform k-opt heuristic search twice
         if kopt:
-            array_p, array_q, error = kopt_heuristic_double(perm_p=array_p, perm_q=array_q,
-                                                            array_m=array_m, array_n=array_n,
-                                                            ref_error=error, kopt_k=kopt_k,
+            array_p, array_q, error = kopt_heuristic_double(array_m=array_m,
+                                                            array_n=array_n,
+                                                            ref_error=error,
+                                                            perm_p=array_p,
+                                                            perm_q=array_q,
+                                                            kopt_k=kopt_k,
                                                             kopt_tol=kopt_tol)
         # return array_m, array_n, array_p, array_q, error
         return ProcrustesResult(new_a=new_a, new_b=new_b,

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -25,8 +25,8 @@
 import itertools as it
 
 import numpy as np
-from procrustes.utils import (compute_error, kopt_heuristic_double,
-                              kopt_heuristic_single, ProcrustesResult, setup_input_arrays)
+from procrustes.kopt import kopt_heuristic_double, kopt_heuristic_single
+from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
 from scipy.optimize import linear_sum_assignment
 
 __all__ = [

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# The Procrustes library provides a set of functions for transforming
+# a matrix to make it as similar as possible to a target matrix.
+#
+# Copyright (C) 2017-2020 The Procrustes Development Team
+#
+# This file is part of Procrustes.
+#
+# Procrustes is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# Procrustes is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Test Module for Kopt."""
+
+import numpy as np
+from numpy.testing import assert_equal, assert_raises
+from procrustes.kopt import kopt_heuristic_double, kopt_heuristic_single
+from procrustes.utils import compute_error
+
+
+def test_kopt_heuristic_single():
+    r"""Test k-opt heuristic search algorithm."""
+    arr_a = np.array([[3, 6, 1, 0, 7],
+                      [4, 5, 2, 7, 6],
+                      [8, 6, 6, 1, 7],
+                      [4, 4, 7, 9, 4],
+                      [4, 8, 0, 3, 1]])
+    arr_b = np.array([[1, 8, 0, 4, 3],
+                      [6, 5, 2, 4, 7],
+                      [7, 6, 6, 8, 1],
+                      [7, 6, 1, 3, 0],
+                      [4, 4, 7, 4, 9]])
+    perm_guess = np.array([[0, 0, 1, 0, 0],
+                           [1, 0, 0, 0, 0],
+                           [0, 0, 0, 1, 0],
+                           [0, 0, 0, 0, 1],
+                           [0, 1, 0, 0, 0]])
+    perm_exact = np.array([[0, 0, 0, 1, 0],
+                           [0, 1, 0, 0, 0],
+                           [0, 0, 1, 0, 0],
+                           [0, 0, 0, 0, 1],
+                           [1, 0, 0, 0, 0]])
+    error_old = compute_error(arr_a, arr_b, perm_guess, perm_guess)
+    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, error_old,
+                                             perm_guess, 3, kopt_tol=1.e-8)
+    assert_equal(perm, perm_exact)
+    assert kopt_error == 0
+    # test the error exceptions
+    assert_raises(ValueError, kopt_heuristic_single, arr_a,
+                  arr_b, error_old, perm_guess, 1, kopt_tol=1.e-8)
+
+
+def test_kopt_heuristic_double():
+    r"""Test double sided k-opt heuristic search algorithm."""
+    np.random.seed(998)
+    arr_b = np.random.randint(low=-10, high=10, size=(4, 3)).astype(np.float)
+    perm1 = np.array([[0., 0., 0., 1.],
+                      [0., 1., 0., 0.],
+                      [1., 0., 0., 0.],
+                      [0., 0., 1., 0.]])
+    perm2 = np.array([[0., 0., 1.],
+                      [1., 0., 0.],
+                      [0., 1., 0.]])
+    arr_a = np.linalg.multi_dot([perm1.T, arr_b, perm2])
+    # shuffle the permutation matrices
+    perm1_shuff = np.array([[0., 0., 0., 1.],
+                            [1., 0., 0., 0.],
+                            [0., 1., 0., 0.],
+                            [0., 0., 1., 0.]])
+    perm2_shuff = np.array([[1., 0., 0.],
+                            [0., 0., 1.],
+                            [0., 1., 0.]])
+    error = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
+    perm_left, perm_right, kopt_error = kopt_heuristic_double(perm_p=perm1_shuff,
+                                                              perm_q=perm2_shuff,
+                                                              array_m=arr_a, array_n=arr_b,
+                                                              ref_error=error, kopt_k=4,
+                                                              kopt_tol=1.e-8)
+    _, _, kopt_error = kopt_heuristic_double(perm_p=perm_left, perm_q=perm_right,
+                                             array_m=arr_a, array_n=arr_b,
+                                             ref_error=error, kopt_k=3, kopt_tol=1.e-8)
+    assert kopt_error <= error
+    assert kopt_error == 0

--- a/procrustes/test/test_utils.py
+++ b/procrustes/test/test_utils.py
@@ -23,10 +23,8 @@
 """Utils module for Procrustes."""
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_raises
-from procrustes.utils import (_hide_zero_padding, _scale_array,
-                              _translate_array, _zero_padding, compute_error,
-                              kopt_heuristic_double, kopt_heuristic_single)
+from numpy.testing import assert_almost_equal, assert_raises
+from procrustes.utils import _hide_zero_padding, _scale_array, _translate_array, _zero_padding
 
 
 def test_zero_padding_rows():
@@ -350,68 +348,3 @@ def test_scale_array():
     # array_trans_scale should be identical to array after the above analysis
     expected = array_a
     assert (abs(predicted - expected) < 1.e-10).all()
-
-
-def test_kopt_heuristic_single():
-    r"""Test k-opt heuristic search algorithm."""
-    arr_a = np.array([[3, 6, 1, 0, 7],
-                      [4, 5, 2, 7, 6],
-                      [8, 6, 6, 1, 7],
-                      [4, 4, 7, 9, 4],
-                      [4, 8, 0, 3, 1]])
-    arr_b = np.array([[1, 8, 0, 4, 3],
-                      [6, 5, 2, 4, 7],
-                      [7, 6, 6, 8, 1],
-                      [7, 6, 1, 3, 0],
-                      [4, 4, 7, 4, 9]])
-    perm_guess = np.array([[0, 0, 1, 0, 0],
-                           [1, 0, 0, 0, 0],
-                           [0, 0, 0, 1, 0],
-                           [0, 0, 0, 0, 1],
-                           [0, 1, 0, 0, 0]])
-    perm_exact = np.array([[0, 0, 0, 1, 0],
-                           [0, 1, 0, 0, 0],
-                           [0, 0, 1, 0, 0],
-                           [0, 0, 0, 0, 1],
-                           [1, 0, 0, 0, 0]])
-    error_old = compute_error(arr_a, arr_b, perm_guess, perm_guess)
-    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, error_old,
-                                             perm_guess, 3, kopt_tol=1.e-8)
-    assert_equal(perm, perm_exact)
-    assert kopt_error == 0
-    # test the error exceptions
-    assert_raises(ValueError, kopt_heuristic_single, arr_a,
-                  arr_b, error_old, perm_guess, 1, kopt_tol=1.e-8)
-
-
-def test_kopt_heuristic_double():
-    r"""Test double sided k-opt heuristic search algorithm."""
-    np.random.seed(998)
-    arr_b = np.random.randint(low=-10, high=10, size=(4, 3)).astype(np.float)
-    perm1 = np.array([[0., 0., 0., 1.],
-                      [0., 1., 0., 0.],
-                      [1., 0., 0., 0.],
-                      [0., 0., 1., 0.]])
-    perm2 = np.array([[0., 0., 1.],
-                      [1., 0., 0.],
-                      [0., 1., 0.]])
-    arr_a = np.linalg.multi_dot([perm1.T, arr_b, perm2])
-    # shuffle the permutation matrices
-    perm1_shuff = np.array([[0., 0., 0., 1.],
-                            [1., 0., 0., 0.],
-                            [0., 1., 0., 0.],
-                            [0., 0., 1., 0.]])
-    perm2_shuff = np.array([[1., 0., 0.],
-                            [0., 0., 1.],
-                            [0., 1., 0.]])
-    error = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
-    perm_left, perm_right, kopt_error = kopt_heuristic_double(perm_p=perm1_shuff,
-                                                              perm_q=perm2_shuff,
-                                                              array_m=arr_a, array_n=arr_b,
-                                                              ref_error=error, kopt_k=4,
-                                                              kopt_tol=1.e-8)
-    _, _, kopt_error = kopt_heuristic_double(perm_p=perm_left, perm_q=perm_right,
-                                             array_m=arr_a, array_n=arr_b,
-                                             ref_error=error, kopt_k=3, kopt_tol=1.e-8)
-    assert kopt_error <= error
-    assert kopt_error == 0

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -22,16 +22,11 @@
 # --
 """Utility Module."""
 
-from copy import deepcopy
-import itertools as it
-
 import numpy as np
 
 __all__ = [
     "compute_error",
     "setup_input_arrays",
-    "kopt_heuristic_single",
-    "kopt_heuristic_double",
     "ProcrustesResult",
 ]
 
@@ -426,138 +421,6 @@ def _check_arraytypes(*args):
         raise TypeError("Matrix inputs must be NumPy arrays")
     if any(x.ndim != 2 for x in args):
         raise TypeError("Matrix inputs must be 2-dimensional arrays")
-
-
-def kopt_heuristic_single(array_a, array_b, ref_error, perm=None, kopt_k=3, kopt_tol=1.e-8):
-    r"""K-opt heuristic to improve the accuracy for two-sided permutation with one transformation.
-
-    Perform k-opt local search with every possible valid combination of the swapping mechanism.
-
-    Parameters
-    ----------
-    array_a : ndarray
-        The array to be permuted.
-    array_b : ndarray
-        The reference array.
-    ref_error : float
-        The reference error value.
-    perm : ndarray, optional
-        The permutation array which remains to be processed with k-opt local search. Default is the
-        identity matrix with the same shape of array_a.
-    kopt_k : int, optional
-        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
-        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
-    kopt_tol : float, optional
-        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
-
-    Returns
-    -------
-    perm : ndarray
-        The permutation array after optimal heuristic search.
-    kopt_error : float
-        The error distance of two arrays with the updated permutation array.
-    """
-    if kopt_k < 2:
-        raise ValueError("Kopt_k value must be a integer greater than 2.")
-    # if perm is not specified, use the identity matrix as default
-    if perm is None:
-        perm = np.identity(np.shape(array_a)[0])
-    num_row = perm.shape[0]
-    kopt_error = ref_error
-    # all the possible row-wise permutations
-    for comb in it.combinations(np.arange(num_row), r=kopt_k):
-        for comb_perm in it.permutations(comb, r=kopt_k):
-            if comb_perm != comb:
-                perm_kopt = deepcopy(perm)
-                perm_kopt[comb, :] = perm_kopt[comb_perm, :]
-                e_kopt_new = compute_error(array_a, array_b, perm_kopt, perm_kopt)
-                if e_kopt_new < kopt_error:
-                    perm = perm_kopt
-                    kopt_error = e_kopt_new
-                    if kopt_error <= kopt_tol:
-                        break
-    return perm, kopt_error
-
-
-def kopt_heuristic_double(array_m, array_n, ref_error,
-                          perm_p=None, perm_q=None,
-                          kopt_k=3, kopt_tol=1.e-8):
-    r"""
-    K-opt kopt for regular two-sided permutation Procrustes to improve the accuracy.
-
-    Perform k-opt local search with every possible valid combination of the swapping mechanism for
-    regular 2-sided permutation Procrustes.
-
-    Parameters
-    ----------
-    array_m : ndarray
-        The array to be permuted.
-    array_n : ndarray
-        The reference array.
-    ref_error : float
-        The reference error value.
-    perm_p : ndarray, optional
-        The left permutation array which remains to be processed with k-opt local search. Default
-        is the identity matrix with the same shape of array_m.
-    perm_q : ndarray, optional
-        The right permutation array which remains to be processed with k-opt local search. Default
-        is the identity matrix with the same shape of array_m.
-    kopt_k : int, optional
-        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
-        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
-    kopt_tol : float, optional
-        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
-
-    Returns
-    -------
-    perm_kopt_p : ndarray
-        The left permutation array after optimal heuristic search.
-    perm_kopt_q : ndarray
-        The right permutation array after optimal heuristic search.
-    kopt_error : float
-        The error distance of two arrays with the updated permutation array.
-    """
-    if kopt_k < 2:
-        raise ValueError("Kopt_k value must be a integer greater than 2.")
-    # if perm_p is not specified, use the identity matrix as default
-    if perm_p is None:
-        perm_p = np.identity(np.shape(array_m)[0])
-    # if perm_p is not specified, use the identity matrix as default
-    if perm_q is None:
-        perm_q = np.identity(np.shape(array_m)[0])
-
-    num_row_left = perm_p.shape[0]
-    num_row_right = perm_q.shape[0]
-    kopt_error = ref_error
-    # the left hand side permutation
-    # pylint: disable=too-many-nested-blocks
-    for comb_left in it.combinations(np.arange(num_row_left), r=kopt_k):
-        for comb_perm_left in it.permutations(comb_left, r=kopt_k):
-            if comb_perm_left != comb_left:
-                perm_kopt_left = deepcopy(perm_p)
-                # the right hand side permutation
-                for comb_right in it.combinations(np.arange(num_row_right), r=kopt_k):
-                    for comb_perm_right in it.permutations(comb_right, r=kopt_k):
-                        if comb_perm_right != comb_right:
-                            perm_kopt_right = deepcopy(perm_q)
-                            perm_kopt_right[comb_right, :] = perm_kopt_right[comb_perm_right, :]
-                            e_kopt_new_right = compute_error(array_n, array_m, perm_p.T,
-                                                             perm_kopt_right)
-                            if e_kopt_new_right < kopt_error:
-                                perm_q = perm_kopt_right
-                                kopt_error = e_kopt_new_right
-                                if kopt_error <= kopt_tol:
-                                    break
-
-                perm_kopt_left[comb_left, :] = perm_kopt_left[comb_perm_left, :]
-                e_kopt_new_left = compute_error(array_n, array_m, perm_kopt_left.T, perm_q)
-                if e_kopt_new_left < kopt_error:
-                    perm_p = perm_kopt_left
-                    kopt_error = e_kopt_new_left
-                    if kopt_error <= kopt_tol:
-                        break
-
-    return perm_p, perm_q, kopt_error
 
 
 class ProcrustesResult(dict):


### PR DESCRIPTION
K-opt heuristic local search algorithms should not belong to the `utils` module and move them to be a separate module is a good choice.

- [x] Move k-opt heuristic algorithms out from utils.py
- [x] Add tests for k-opt module and update tests for the `utils` module
- [x] Update imports for permutation Procrustes w.r.t. this change
- [x] The arguments are also specified to avoid some confusion and potential bugs

This PR fixed issue, #41