### PR TITLE
Refactor compute_error and ProcrustesResult

### DIFF
--- a/procrustes/generalized.py
+++ b/procrustes/generalized.py
@@ -112,4 +112,4 @@ def _orthogonal(arr_a, arr_b):
                      translate=False,
                      scale=False)
 
-    return np.dot(res["new_a"], res["array_u"])
+    return np.dot(res["new_a"], res["t"])

--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -83,18 +83,7 @@ def generic(array_a, array_b,
     Returns
     -------
     res : ProcrustesResult
-        Procrustes analysis result object.
-
-    Attributes
-    ----------
-    new_a : ndarray
-        The transformed ndarray array_a.
-    new_b : ndarray
-        The transformed ndarray array_b.
-    array_u : ndarray
-        The optimum symmetric transformation array.
-    error : float
-        One-sided Procrustes error.
+        The Procrustes result represented as a class:`utils.ProcrustesResult` object.
 
     Notes
     -----
@@ -124,4 +113,4 @@ def generic(array_a, array_b,
     a_inv = np.linalg.pinv(np.dot(new_a.T, new_a))
     array_x = np.linalg.multi_dot([a_inv, new_a.T, new_b])
     e_opt = compute_error(new_a, new_b, array_x)
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_x, error=e_opt)
+    return ProcrustesResult(error=e_opt, new_a=new_a, new_b=new_b, t=array_x, s=None)

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -92,19 +92,8 @@ def orthogonal(array_a, array_b,
 
     Returns
     -------
-    res: ProcrustesResult
-        Procrustes analysis result object.
-
-    Attributes
-    ----------
-    new_a : ndarray
-        The transformed ndarray :math:`A`.
-    new_b : ndarray
-        The transformed ndarray :math:`B`.
-    array_u : ndarray
-        The optimum orthogonal transformation matrix.
-    error : float
-        One-sided orthogonal Procrustes error.
+    res : ProcrustesResult
+        The Procrustes result represented as a class:`utils.ProcrustesResult` object.
 
     Notes
     -----
@@ -173,7 +162,7 @@ def orthogonal(array_a, array_b,
     # compute the error
     error = compute_error(new_a, new_b, array_u_opt)
     # return new_a, new_b, array_u_opt, error
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u_opt, error=error)
+    return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u_opt, s=None)
 
 
 def orthogonal_2sided(array_a, array_b,
@@ -234,22 +223,7 @@ def orthogonal_2sided(array_a, array_b,
     Returns
     -------
     res : ProcrustesResult
-        Procrustes analysis result object.
-
-    Attributes
-    ----------
-    array_a : ndarray
-        The transformed ndarray :math:`A`.
-    array_b : ndarray
-        The transformed ndarray :math:`B`.
-    array_u : ndarray
-        The transformation ndarray if "single_transform=False".
-    array_p : ndarray
-        The optimal orthogonal left-multiplying transformation ndarray if "single_transform=True".
-    array_q : ndarray
-        The second transformation ndarray if "single_transform=True".
-    error : float
-        The single- or double- sided orthogonal Procrustes error.
+        The Procrustes result represented as a class:`utils.ProcrustesResult` object.
 
     Raises
     ------
@@ -377,12 +351,11 @@ def orthogonal_2sided(array_a, array_b,
         u_opt = array_ua.dot(array_ub.T)
 
         error = compute_error(new_a, new_b, u_opt, u_opt)
-        return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, error=error)
+        return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=u_opt, s=u_opt)
     # Do regular two-sided orthogonal Procrustes calculations
     u_opt1, u_opt2 = _2sided(new_a, new_b)
     error = compute_error(new_a, new_b, u_opt1, u_opt2)
-    return ProcrustesResult(new_a=new_a, new_b=new_b,
-                            array_p=u_opt1, array_q=u_opt2, error=error)
+    return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=u_opt2, s=u_opt1)
 
 
 def _2sided(array_a, array_b):

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -89,8 +89,8 @@ def permutation(array_a, array_b,
 
     Returns
     -------
-    res: ProcrustesResult
-        Procrustes analysis result object.
+    res : ProcrustesResult
+        The Procrustes result represented as a class:`utils.ProcrustesResult` object.
 
     Attributes
     ----------
@@ -152,7 +152,7 @@ def permutation(array_a, array_b,
     array_u[linear_sum_assignment(array_c)] = 1
     error = compute_error(new_a, new_b, array_u)
     # return new_a, new_b, array_u, error
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u, error=error)
+    return ProcrustesResult(new_a=new_a, new_b=new_b, t=array_u, error=error)
 
 
 def permutation_2sided(array_a, array_b, transform_mode="single",
@@ -240,22 +240,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
     Returns
     -------
     res : ProcrustesResult
-        Procrustes analysis result object.
-
-    Attributes
-    ----------
-    new_a : ndarray
-        The transformed ndarray A.
-    new_b : ndarray
-        The transformed ndarray B.
-    array_u : ndarray
-        The optimum permutation transformation matrix.
-    array_p : ndarray
-        The optimum permutation transformation matrix when using double transform mode.
-    array_q : ndarray
-        The optimum permutation transformation matrix when using double transform mode.
-    error : float
-        Two-sided permutation Procrustes error.
+        The Procrustes result represented as a class:`utils.ProcrustesResult` object.
 
     Notes
     -----
@@ -456,7 +441,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
                                                        perm=array_u,
                                                        kopt_k=kopt_k,
                                                        kopt_tol=kopt_tol)
-        return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_u, error=error)
+        return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u, s=None)
 
     # Do regular computation
     elif transform_mode == "double":
@@ -473,8 +458,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
                                                             kopt_k=kopt_k,
                                                             kopt_tol=kopt_tol)
         # return array_m, array_n, array_p, array_q, error
-        return ProcrustesResult(new_a=new_a, new_b=new_b,
-                                array_p=array_p, array_q=array_q, error=error)
+        return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_q, s=array_p)
     else:
         raise ValueError("""Invalid transform_mode argument, use "single"or "double".""")
 
@@ -684,11 +668,11 @@ def _guess_initial_permutation_undirected(array_a, array_b, mode, add_noise):
     if mode == "normal1":
         tmp_a = _2sided_1trans_initial_guess_normal1(array_a)
         tmp_b = _2sided_1trans_initial_guess_normal1(array_b)
-        array_u = permutation(tmp_a, tmp_b)["array_u"]
+        array_u = permutation(tmp_a, tmp_b)["t"]
     elif mode == "normal2":
         tmp_a = _2sided_1trans_initial_guess_normal2(array_a)
         tmp_b = _2sided_1trans_initial_guess_normal2(array_b)
-        array_u = permutation(tmp_a, tmp_b)["array_u"]
+        array_u = permutation(tmp_a, tmp_b)["t"]
     elif mode == "umeyama":
         array_u = _2sided_1trans_initial_guess_umeyama(array_a, array_b, add_noise)
     elif mode == "umeyama_approx":
@@ -727,7 +711,7 @@ def _compute_transform(array_a, array_b, guess, tol, iteration):
 
     p_opt = permutation(array_a=np.eye(p_new.shape[0]), array_b=p_new,
                         remove_zero_col=False, remove_zero_row=False,
-                        translate=False, scale=False, check_finite=True)["array_u"]
+                        translate=False, scale=False, check_finite=True)["t"]
 
     return p_opt
 
@@ -751,7 +735,7 @@ def _compute_transform_directed(array_a, array_b, guess, tol, iteration):
         p_old = p_new
         if step == iteration:
             print("Maximum iteration reached! Change={0}".format(change))
-    p_opt = permutation(np.eye(p_new.shape[0]), p_new)["array_u"]
+    p_opt = permutation(np.eye(p_new.shape[0]), p_new)["t"]
 
     return p_opt
 
@@ -808,18 +792,7 @@ def permutation_2sided_explicit(array_a, array_b,
     Returns
     -------
     res : ProcrustesResult
-        Procrustes analysis result object.
-
-    Attributes
-    ----------
-    new_a : ndarray
-        The transformed ndarray A.
-    new_b : ndarray
-        The transformed ndarray B.
-    array_u : ndarray
-        The optimum permutation transformation matrix.
-    error : float
-        Two-sided orthogonal Procrustes error.
+        The Procrustes result represented as a class:`utils.ProcrustesResult` object.
 
     Notes
     -----
@@ -848,5 +821,4 @@ def permutation_2sided_explicit(array_a, array_b,
         if perm_error2 < perm_error1:
             perm_error1 = perm_error2
             perm1 = perm2
-    # return new_a, new_b, perm1, perm_error1
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=perm1, error=perm_error1)
+    return ProcrustesResult(error=perm_error1, new_a=new_a, new_b=new_b, t=perm1, s=None)

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -85,18 +85,7 @@ def rotational(array_a, array_b,
     Returns
     -------
     res : ProcrustesResult
-        Procrustes analysis result object.
-
-    Attributes
-    ----------
-    new_a : ndarray
-        The transformed ndarray :math:`A`.
-    new_b : ndarray
-        The transformed ndarray :math:`B`.
-    array_u : ndarray
-        The optimum rotational transformation matrix.
-    error : float
-        One-sided orthogonal Procrustes error.
+        The Procrustes result represented as a class:`utils.ProcrustesResult` object.
 
     Notes
     -----
@@ -176,4 +165,4 @@ def rotational(array_a, array_b,
     # compute single-sided error error
     error = compute_error(new_a, new_b, u_opt)
 
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=u_opt, error=error)
+    return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=u_opt, s=None)

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -135,18 +135,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
     Returns
     -------
     res : ProcrustesResult
-        Procrustes analysis result object.
-
-    Attributes
-    ----------
-    new_a : ndarray
-        The transformed ndarray A.
-    new_b : ndarray
-        The transformed ndarray B.
-    array_u : ndarray
-        The optimum permutation transformation matrix.
-    error : float
-        Two-sided Procrustes error.
+        The Procrustes result represented as a class:`utils.ProcrustesResult` object.
 
     Notes
     -----
@@ -315,7 +304,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
             epsilon_sink = epsilon_soft * k
 
     # Compute the error
-    array_m = permutation(np.eye(array_m.shape[0]), array_m)["array_u"]
+    array_m = permutation(np.eye(array_m.shape[0]), array_m)["t"]
     error = compute_error(new_a, new_b, array_m, array_m)
     # k-opt heuristic
     if kopt:
@@ -325,7 +314,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
                                                perm=array_m,
                                                kopt_k=kopt_k,
                                                kopt_tol=kopt_tol)
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_m, error=error)
+    return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_m, s=None)
 
 
 def _compute_gamma(array_c, row_num, gamma_scaler):

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -82,18 +82,7 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     Returns
     -------
     res : ProcrustesResult
-        Procrustes analysis result object.
-
-    Attributes
-    ----------
-    new_a : ndarray
-        The transformed ndarray array_a.
-    new_b : ndarray
-        The transformed ndarray array_b.
-    array_u : ndarray
-        The optimum symmetric transformation array.
-    error : float
-        One-sided Procrustes error.
+        The Procrustes result represented as a class:`utils.ProcrustesResult` object.
 
     Raises
     ------
@@ -193,4 +182,4 @@ def symmetric(array_a, array_b, remove_zero_col=True, remove_zero_row=True,
     array_x = np.dot(np.dot(array_vt.T, array_y), array_vt)
     error = compute_error(new_a, new_b, array_x)
 
-    return ProcrustesResult(new_a=new_a, new_b=new_b, array_u=array_x, error=error)
+    return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_x, s=None)

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -43,7 +43,7 @@ def test_generic_transformed():
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=False, scale=False)
     # check transformation is right & error is zero
-    assert_almost_equal(res["array_u"], array_x, decimal=6)
+    assert_almost_equal(res["t"], array_x, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
@@ -60,7 +60,7 @@ def test_generic_transformed_negative():
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=False, scale=False)
     # check transformation is right & error is zero
-    assert_almost_equal(res["array_u"], array_x, decimal=6)
+    assert_almost_equal(res["t"], array_x, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
@@ -77,7 +77,7 @@ def test_generic_transformed_translate():
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=True, scale=False)
     # check transformation is right & error is zero
-    assert_almost_equal(res["array_u"], array_x, decimal=6)
+    assert_almost_equal(res["t"], array_x, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
@@ -123,5 +123,5 @@ def test_generic_random_transformation():
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=False, scale=False)
     # check transformation is right & error is zero
-    assert_almost_equal(res["array_u"], array_x, decimal=6)
+    assert_almost_equal(res["t"], array_x, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -45,24 +45,24 @@ def test_procrustes_orthogonal_identical():
     # check transformation array is identity
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # case of identical rectangular arrays (2 by 4)
     array_a = np.array([[1, 5, 6, 7], [1, 2, 9, 4]])
     array_b = np.copy(array_a)
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_equal(res["array_u"].shape, (4, 4))
+    assert_equal(res["t"].shape, (4, 4))
     # assert_almost_equal(array_u, np.eye(4), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # case of identical rectangular arrays (5 by 3)
     array_a = np.arange(15).reshape(5, 3)
     array_b = np.copy(array_a)
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_equal(res["array_u"].shape, (3, 3))
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_equal(res["t"].shape, (3, 3))
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
 
 
 def test_procrustes_rotation_square():
@@ -72,38 +72,38 @@ def test_procrustes_rotation_square():
     # rotation by 90 degree
     array_b = np.array([[1, 0], [3, -2]])
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["array_u"], np.array([[0., -1.], [1., 0.]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.array([[0., -1.], [1., 0.]]), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # rotation by 180 degree
     array_b = -array_a
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["array_u"], np.array([[-1., 0.], [0., -1.]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.array([[-1., 0.], [0., -1.]]), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # rotation by 270 degree
     array_b = np.array([[-1, 0], [-3, 2]])
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["array_u"], np.array([[0., 1.], [-1., 0.]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.array([[0., 1.], [-1., 0.]]), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # rotation by 45 degree
     rotation = 0.5 * np.sqrt(2) * np.array([[1, -1], [1, 1]])
     array_b = np.dot(array_a, rotation)
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["array_u"], rotation, decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], rotation, decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # rotation by 30 degree
     theta = np.pi / 6
     rotation = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
     array_b = np.dot(array_a, rotation)
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["array_u"], rotation, decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], rotation, decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # rotation by 72 degree
     theta = 1.25664
     rotation = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
     array_b = np.dot(array_a, rotation)
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["array_u"], rotation, decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], rotation, decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
 
 
 def test_procrustes_reflection_square():
@@ -115,23 +115,23 @@ def test_procrustes_reflection_square():
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_almost_equal(res["array_u"], np.array([[-1, 0], [0, -1]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.array([[-1, 0], [0, -1]]), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # reflection in the x-axis
     array_b = np.array([[2.0, -0.1], [0.5, -3.0]])
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["array_u"], np.array([[1, 0], [0, -1]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.array([[1, 0], [0, -1]]), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # reflection in the y-axis
     array_b = np.array([[-2.0, 0.1], [-0.5, 3.0]])
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["array_u"], np.array([[-1, 0], [0, 1]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.array([[-1, 0], [0, 1]]), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # reflection in the line y=x
     array_b = np.array([[0.1, 2.0], [3.0, 0.5]])
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["array_u"], np.array([[0, 1], [1, 0]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.array([[0, 1], [1, 0]]), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
 
 
 def test_procrustes_shifted():
@@ -143,14 +143,14 @@ def test_procrustes_shifted():
     array_b = array_a + 4.1
     res = orthogonal(array_a, array_b, translate=True)
     # assert_almost_equal(new_b, array_b, decimal=6)
-    assert_almost_equal(res["array_u"], np.eye(3), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.eye(3), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # different shift along each axis
     array_b = array_a + np.array([0, 3.2, 5.0])
     res = orthogonal(array_a, array_b, translate=True)
     # assert_almost_equal(new_b, array_b, decimal=6)
-    assert_almost_equal(res["array_u"], np.eye(3), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.eye(3), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # rectangular (2 by 3)
     array_a = np.array([[1, 2, 3], [7, 9, 5]])
     # expected_a = array_a - np.array([4., 5.5, 4.])
@@ -158,13 +158,13 @@ def test_procrustes_shifted():
     array_b = array_a + 0.71
     res = orthogonal(array_a, array_b, translate=True)
     # assert_almost_equal(new_b, array_b, decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # different shift along each axis
     array_b = array_a + np.array([0.3, 7.1, 4.2])
     res = orthogonal(array_a, array_b, translate=True)
     # assert_almost_equal(new_b, array_b, decimal=6)
-    assert_equal(res["array_u"].shape, (3, 3))
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_equal(res["t"].shape, (3, 3))
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
 
 
 def test_procrustes_rotation_translation():
@@ -180,18 +180,18 @@ def test_procrustes_rotation_translation():
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_almost_equal(res["array_u"], np.dot(rotation, reflection), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.dot(rotation, reflection), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # procrustes with translation
     res = orthogonal(array_a, array_b, translate=True)
     assert_almost_equal(res["new_a"], array_a - np.mean(array_a, axis=0), decimal=6)
     assert_almost_equal(res["new_b"], array_b - np.mean(array_b, axis=0), decimal=6)
-    assert_almost_equal(res["array_u"], np.dot(rotation, reflection), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.dot(rotation, reflection), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
     # procrustes with translation and scaling
     res = orthogonal(array_a, array_b, translate=True, scale=True)
-    assert_almost_equal(res["array_u"], np.dot(rotation, reflection), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.dot(rotation, reflection), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
 
 
 def test_rotation_translate_scale():
@@ -205,8 +205,8 @@ def test_rotation_translate_scale():
     array_b = np.dot(4 * array_a + 3.0, np.dot(rotation, reflection))
     # procrustes with translation and scaling
     res = orthogonal(array_a, array_b, translate=True, scale=True)
-    assert_almost_equal(res["array_u"], np.dot(rotation, reflection), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.dot(rotation, reflection), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
 
 
 def test_orthogonal_translate_scale2():
@@ -224,8 +224,8 @@ def test_orthogonal_translate_scale2():
     array_b = np.concatenate((array_b, np.zeros((5, 7))), axis=0)
     # compute procrustes transformation
     res = orthogonal(array_a, array_b, translate=False, scale=False)
-    assert_almost_equal(res["array_u"], np.dot(rot, ref), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["array_u"]), 0., decimal=6)
+    assert_almost_equal(res["t"], np.dot(rot, ref), decimal=6)
+    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
 
 
 def test_two_sided_orthogonal_identical():
@@ -235,10 +235,10 @@ def test_two_sided_orthogonal_identical():
     array_b = np.copy(array_a)
     result = orthogonal_2sided(array_a, array_b, single_transform=False)
     # check transformation array is identity
-    assert_almost_equal(np.linalg.det(result["array_p"]), 1.0, decimal=6)
-    assert_almost_equal(np.linalg.det(result["array_q"]), 1.0, decimal=6)
-    assert_almost_equal(result["array_p"], np.eye(4), decimal=6)
-    assert_almost_equal(result["array_q"], np.eye(4), decimal=6)
+    assert_almost_equal(np.linalg.det(result["s"]), 1.0, decimal=6)
+    assert_almost_equal(np.linalg.det(result["t"]), 1.0, decimal=6)
+    assert_almost_equal(result["s"], np.eye(4), decimal=6)
+    assert_almost_equal(result["t"], np.eye(4), decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
 
 
@@ -277,10 +277,10 @@ def test_two_sided_orthogonal_rotate_reflect():
     # compute procrustes transformation
     result = orthogonal_2sided(array_a, array_b, translate=True, scale=True, single_transform=False)
     # check transformation array orthogonality
-    assert_almost_equal(np.dot(result["array_p"], result["array_p"].T), np.eye(3), decimal=6)
-    assert_almost_equal(np.dot(result["array_q"], result["array_q"].T), np.eye(3), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(result["array_p"])), 1.0, decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(result["array_q"])), 1.0, decimal=6)
+    assert_almost_equal(np.dot(result["s"], result["s"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(result["s"])), 1.0, decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(result["t"])), 1.0, decimal=6)
     # transformation should return zero error
     assert_almost_equal(result["error"], 0, decimal=6)
 
@@ -300,10 +300,10 @@ def test_two_sided_orthogonal_rotate_reflect_pad():
     # compute Procrustes transformation
     result = orthogonal_2sided(array_a, array_b, translate=True, scale=True, single_transform=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(result["array_p"], result["array_p"].T), np.eye(2), decimal=6)
-    assert_almost_equal(np.dot(result["array_q"], result["array_q"].T), np.eye(2), decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["array_p"])), 1.0, decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["array_q"])), 1.0, decimal=6)
+    assert_almost_equal(np.dot(result["s"], result["s"].T), np.eye(2), decimal=6)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(2), decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result["s"])), 1.0, decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -320,10 +320,10 @@ def test_two_sided_orthogonal_translate_scale_rotate_reflect():
     # compute procrustes transformation
     result = orthogonal_2sided(array_a, array_b, translate=True, scale=True, single_transform=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(result["array_p"], result["array_p"].T), np.eye(3), decimal=6)
-    assert_almost_equal(np.dot(result["array_q"], result["array_q"].T), np.eye(3), decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["array_p"])), 1.0, decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["array_q"])), 1.0, decimal=6)
+    assert_almost_equal(np.dot(result["s"], result["s"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result["s"])), 1.0, decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=6)
     # transformation should return zero error
     assert_almost_equal(result["error"], 0, decimal=6)
 
@@ -341,10 +341,10 @@ def test_two_sided_orthogonal_translate_scale_rotate_reflect_3by3():
     # compute procrustes transformation
     result = orthogonal_2sided(array_a, array_b, translate=True, scale=True, single_transform=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(result["array_p"], result["array_p"].T), np.eye(3), decimal=6)
-    assert_almost_equal(np.dot(result["array_q"], result["array_q"].T), np.eye(3), decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["array_p"])), 1.0, decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["array_q"])), 1.0, decimal=6)
+    assert_almost_equal(np.dot(result["s"], result["s"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result["s"])), 1.0, decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -357,9 +357,9 @@ def test_two_sided_orthogonal_single_transformation_identical():
 
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(4), decimal=8)
-    assert_almost_equal(abs(result["array_u"]), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(4), decimal=8)
+    assert_almost_equal(abs(result["t"]), np.eye(4), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
     assert_almost_equal(result["error"], 0, decimal=8)
 
 
@@ -381,8 +381,8 @@ def test_two_sided_orthogonal_single_transformation_rot_reflect_padded():
 
     # check transformation array and error.
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
     assert_almost_equal(result["error"], 0, decimal=8)
 
 
@@ -401,10 +401,9 @@ def test_two_sided_orthogonal_single_transformation_scale_3by3():
     array_b = np.dot(np.dot(trans.T, 6.9 * array_a), trans)
 
     # check transformation array and error
-    result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
-                               single_transform=True)
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    result = orthogonal_2sided(array_a, array_b, translate=False, scale=True, single_transform=True)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
     assert_almost_equal(result["error"], 0, decimal=8)
 
 
@@ -423,10 +422,9 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
     array_b = np.dot(np.dot(trans.T, 88.89 * array_a), trans)
 
     # check transformation array and error
-    result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
-                               single_transform=True)
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(2), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    result = orthogonal_2sided(array_a, array_b, translate=False, scale=True, single_transform=True)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(2), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
     assert_almost_equal(result["error"], 0, decimal=8)
 
 
@@ -445,10 +443,9 @@ def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
     array_b = np.dot(np.dot(trans.T, 6.9 * array_a), trans)
 
     # check transformation array and error
-    result = orthogonal_2sided(array_a, array_b, translate=False, scale=True,
-                               single_transform=True)
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    result = orthogonal_2sided(array_a, array_b, translate=False, scale=True, single_transform=True)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
     assert_almost_equal(result["error"], 0, decimal=8)
 
 
@@ -464,6 +461,6 @@ def test_two_sided_orthogonal_single_transformation_random_orthogonal():
     array_b = np.dot(np.dot(ortho.T, array_a), ortho)
     # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
-    assert_almost_equal(np.dot(result["array_u"], result["array_u"].T), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["array_u"])), 1.0, decimal=8)
+    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(4), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
     assert_almost_equal(result["error"], 0, decimal=8)

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -44,7 +44,7 @@ def test_permutation_columns():
     array_b = np.dot(array_a, perm)
     # procrustes with no translate and scale
     res = permutation(array_a, array_b)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0., decimal=6)
 
 
@@ -64,7 +64,7 @@ def test_permutation_columns_pad():
                       remove_zero_row=True, translate=False, scale=False)
     assert_almost_equal(res["new_a"], array_a[:, :-1], decimal=6)
     assert_almost_equal(res["new_b"], array_b[:-1, :], decimal=6)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0., decimal=6)
 
 
@@ -78,7 +78,7 @@ def test_permutation_translate_scale():
     array_b = np.dot(array_b, perm)
     # permutation procrustes
     res = permutation(array_a, array_b, translate=True, scale=True)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0., decimal=6)
 
 
@@ -96,7 +96,7 @@ def test_permutation_translate_scale_padd():
     array_b = np.dot(array_b, perm)
     # check
     res = permutation(array_a, array_b, translate=True, scale=True)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0., decimal=6)
 
 
@@ -221,7 +221,7 @@ def test_permutation_2sided_4by4_umeyama():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     res = permutation_2sided(array_a, array_b, transform_mode="single", mode="umeyama")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -238,7 +238,7 @@ def test_permutation_2sided_4by4_umeyama_loop():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         res = permutation_2sided(array_a, array_b, transform_mode="single", mode="umeyama")
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -255,7 +255,7 @@ def test_permutation_2sided_4by4_umeyama_loop_negative():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         res = permutation_2sided(array_a, array_b, transform_mode="single", mode="umeyama")
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -273,7 +273,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale():
     # Check
     res = permutation_2sided(array_a, array_b, transform_mode="single",
                              translate=True, scale=True, mode="umeyama")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -292,7 +292,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale_loop():
         # Check
         res = permutation_2sided(array_a, array_b, transform_mode="single",
                                  translate=True, scale=True, mode="umeyama")
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -316,7 +316,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale_zero_padding():
     # Check
     res = permutation_2sided(array_a, array_b, transform_mode="single",
                              translate=True, scale=True, mode="umeyama")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -333,7 +333,7 @@ def test_permutation_2sided_4by4_umeyama_approx():
     res = permutation_2sided(array_a, array_b,
                              transform_mode="single",
                              mode="umeyama_approx")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -352,7 +352,7 @@ def test_permutation_2sided_4by4_umeyama_approx_loop():
         res = permutation_2sided(array_a, array_b,
                                  transform_mode="single",
                                  mode="umeyama_approx")
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -371,7 +371,7 @@ def test_permutation_2sided_umeyama_approx_4by4_loop_negative():
         res = permutation_2sided(array_a, array_b,
                                  transform_mode="single",
                                  mode="umeyama_approx")
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -389,7 +389,7 @@ def test_permutation_2sided_4by4_umeyama_approx_translate_scale():
     # Check
     res = permutation_2sided(array_a, array_b, transform_mode="single",
                              translate=True, scale=True, mode="umeyama_approx")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -411,7 +411,7 @@ def test_permutation_2sided_4by4_umeyama_approx_translate_scale_zero_padding():
     # Check
     res = permutation_2sided(array_a, array_b, translate=True, scale=True,
                              transform_mode="single", mode="umeyama_approx")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -425,7 +425,7 @@ def test_permutation_2sided_4by4_normal1():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     res = permutation_2sided(array_a, array_b, transform_mode="single", mode="normal1")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -447,7 +447,7 @@ def test_permutation_2sided_4by4_normal1_loop():
                                      transform_mode="single",
                                      mode="normal1",
                                      iteration=700)
-            assert_almost_equal(res["array_u"], perm, decimal=6)
+            assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -467,7 +467,7 @@ def test_permutation_2sided_4by4_normal1_loop_negative():
             # Check
             res = permutation_2sided(array_a, array_b, transform_mode="single",
                                      translate=True, scale=True, mode="normal1")
-            assert_almost_equal(res["array_u"], perm, decimal=6)
+            assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -483,7 +483,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale():
     res = permutation_2sided(
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal1")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -503,7 +503,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale_loop():
         res = permutation_2sided(
             array_a, array_b, transform_mode="single",
             translate=True, scale=True, mode="normal1")
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -525,7 +525,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale_zero_padding():
     res = permutation_2sided(
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal1")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -551,7 +551,7 @@ def test_permutation_2sided_normal1_practical_example():
     res = permutation_2sided(
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal1")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -566,7 +566,7 @@ def test_permutation_2sided_4by4_normal2():
     # Check
     res = permutation_2sided(
         array_a, array_b, transform_mode="single", mode="normal2")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -586,7 +586,7 @@ def test_permutation_2sided_4by4_normal2_loop():
             res = permutation_2sided(
                 array_a, array_b, transform_mode="single",
                 translate=True, scale=True, mode="normal2")
-            assert_almost_equal(res["array_u"], perm, decimal=6)
+            assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -606,7 +606,7 @@ def test_permutation_2sided_4by4_normal2_loop_negative():
             res = permutation_2sided(
                 array_a, array_b, transform_mode="single",
                 translate=True, scale=True, mode="normal2")
-            assert_almost_equal(res["array_u"], perm, decimal=6)
+            assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -621,7 +621,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale():
     res = permutation_2sided(
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal2")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -640,7 +640,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale_loop():
         res = permutation_2sided(
             array_a, array_b, transform_mode="single",
             translate=True, scale=True, mode="normal2")
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -661,7 +661,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale_zero_padding():
     res = permutation_2sided(
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal2")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -686,7 +686,7 @@ def test_permutation_2sided_normal2_practical_example():
     res = permutation_2sided(
         array_a, array_b, transform_mode="single",
         translate=True, scale=True, mode="normal2")
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -730,8 +730,8 @@ def test_permutation_2sided_regular():
                         [0, 0, 1, 0, 0],
                         [1, 0, 0, 0, 0]])
     result = permutation_2sided(array_m, array_n, transform_mode="double")
-    assert_almost_equal(result["array_p"], array_p, decimal=6)
-    assert_almost_equal(result["array_q"], array_q, decimal=6)
+    assert_almost_equal(result["s"], array_p, decimal=6)
+    assert_almost_equal(result["t"], array_q, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -749,8 +749,8 @@ def test_permutation_2sided_regular2():
     array_q = array_p.T
     array_m = np.dot(np.dot(array_p, array_n), array_q)
     result = permutation_2sided(array_m, array_n, transform_mode="double")
-    assert_almost_equal(result["array_p"], array_p, decimal=6)
-    assert_almost_equal(result["array_q"], array_q, decimal=6)
+    assert_almost_equal(result["s"], array_p, decimal=6)
+    assert_almost_equal(result["t"], array_q, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -762,8 +762,8 @@ def test_permutation_2sided_regular_unsquared():
     perm_q = np.array([[0, 1], [1, 0]])
     array_m = np.linalg.multi_dot([perm_p, array_n, perm_q])
     result = permutation_2sided(array_m, array_n, transform_mode="double", iteration=500)
-    assert_almost_equal(result["array_p"], perm_p, decimal=6)
-    assert_almost_equal(result["array_q"], perm_q, decimal=6)
+    assert_almost_equal(result["s"], perm_p, decimal=6)
+    assert_almost_equal(result["t"], perm_q, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -777,8 +777,8 @@ def test_permutation_2sided_regular_unsquared_negative():
     perm_q = np.random.permutation(np.eye(4, 4))
     array_m = np.linalg.multi_dot([perm_p, array_n, perm_q])
     result = permutation_2sided(array_m, array_n, transform_mode="double", iteration=500)
-    assert_almost_equal(result["array_p"], perm_p, decimal=6)
-    assert_almost_equal(result["array_q"], perm_q, decimal=6)
+    assert_almost_equal(result["s"], perm_p, decimal=6)
+    assert_almost_equal(result["t"], perm_q, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -792,7 +792,7 @@ def test_permutation_2sided_4by4_directed():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Procrustes with no translate and scale
     result = permutation_2sided(array_a, array_b, transform_mode="single")
-    assert_almost_equal(result["array_u"], perm, decimal=6)
+    assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
 
 
@@ -806,7 +806,7 @@ def test_permutation_2sided_4by4_directed_symmetric():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Procrustes with no translate and scale
     result = permutation_2sided(array_a, array_b, transform_mode="single")
-    assert_almost_equal(result["array_u"], perm, decimal=6)
+    assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
 
 
@@ -822,7 +822,7 @@ def test_permutation_2sided_4by4_directed_loop():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # check
         result = permutation_2sided(array_a, array_b, transform_mode="single")
-        assert_almost_equal(result["array_u"], perm, decimal=6)
+        assert_almost_equal(result["t"], perm, decimal=6)
         assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -838,7 +838,7 @@ def test_permutation_2sided_4by4_directed_netative_loop():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # check
         result = permutation_2sided(array_a, array_b, transform_mode="single")
-        assert_almost_equal(result["array_u"], perm, decimal=6)
+        assert_almost_equal(result["t"], perm, decimal=6)
         assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -855,7 +855,7 @@ def test_permutation_2sided_4by4_directed_translate_scale():
     result = permutation_2sided(array_a, array_b,
                                 transform_mode="single",
                                 translate=True, scale=True)
-    assert_almost_equal(result["array_u"], perm, decimal=6)
+    assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
 
 
@@ -877,7 +877,7 @@ def test_permutation_2sided_4by4_directed_translate_scale_padding():
                                 transform_mode="single",
                                 translate=True,
                                 scale=True)
-    assert_almost_equal(result["array_u"], perm, decimal=6)
+    assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
 
 
@@ -894,7 +894,7 @@ def test_permutation_2sided_explicit_4by4_loop():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # check
         result = permutation_2sided_explicit(array_a, array_b)
-        assert_almost_equal(result["array_u"], perm, decimal=6)
+        assert_almost_equal(result["t"], perm, decimal=6)
         assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -911,7 +911,7 @@ def test_permutation_2sided_explicit_4by4_loop_negative():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # check
         result = permutation_2sided_explicit(array_a, array_b)
-        assert_almost_equal(result["array_u"], perm, decimal=6)
+        assert_almost_equal(result["t"], perm, decimal=6)
         assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -928,7 +928,7 @@ def test_permutation_2sided_explicit_4by4_translate_scale():
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + shift), perm))
     # check
     result = permutation_2sided_explicit(array_a, array_b, translate=True, scale=True)
-    assert_almost_equal(result["array_u"], perm, decimal=6)
+    assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -949,7 +949,7 @@ def test_permutation_2sided_explicit_4by4_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # check
     result = permutation_2sided_explicit(array_a, array_b, translate=True, scale=True)
-    assert_almost_equal(result["array_u"], perm, decimal=6)
+    assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -975,7 +975,7 @@ def test_permutation_2sided_add_noise_mode_umeyama():
     # test umeyama method
     result = permutation_2sided(array_a, array_b, translate=False,
                                 scale=False, mode="umeyama", add_noise=True)
-    assert_almost_equal(result["array_u"], perm, decimal=6)
+    assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -989,7 +989,7 @@ def test_permutation_2sided_add_noise_mode_umeyama_approx():
     # test umeyama method
     result = permutation_2sided(array_a, array_b, translate=False, scale=False,
                                 mode="umeyama_approx", add_noise=True)
-    assert_almost_equal(result["array_u"], perm, decimal=6)
+    assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
@@ -1018,4 +1018,4 @@ def test_permutation_2sided_dominators_zero():
                      [0, 0, 1, 0, 0, 0, 0],
                      [0, 0, 0, 0, 0, 1, 0],
                      [0, 0, 0, 0, 0, 0, 1]])
-    assert_almost_equal(res["array_u"], perm)
+    assert_almost_equal(res["t"], perm)

--- a/procrustes/test/test_rotational.py
+++ b/procrustes/test/test_rotational.py
@@ -35,8 +35,8 @@ def test_rotational_orthogonal_identical():
     # compute Procrustes transformation
     res = rotational(array_a, array_b, translate=False, scale=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(4), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(np.dot(res["t"], res["t"].T), np.eye(4), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["t"])), 1.0, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -53,8 +53,8 @@ def test_rotational_orthogonal_rotation_pad():
     # compute procrustes transformation
     res = rotational(array_a, array_b, translate=False, scale=False)
     # check transformation array and error
-    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(2), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(np.dot(res["t"], res["t"].T), np.eye(2), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["t"])), 1.0, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -71,8 +71,8 @@ def test_rotational_orthogonal_rotation_translate_scale():
     # compute procrustes transformation
     res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(np.dot(res["t"], res["t"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["t"])), 1.0, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -91,8 +91,8 @@ def test_rotational_orthogonal_rotation_translate_scale_4by3():
     # compute procrustes transformation
     res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(np.dot(res["t"], res["t"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["t"])), 1.0, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -111,6 +111,6 @@ def test_rotational_orthogonal_zero_array():
     # compute procrustes transformation
     res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(res["array_u"], res["array_u"].T), np.eye(3), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(res["array_u"])), 1.0, decimal=6)
+    assert_almost_equal(np.dot(res["t"], res["t"].T), np.eye(3), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res["t"])), 1.0, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)

--- a/procrustes/test/test_softassign.py
+++ b/procrustes/test/test_softassign.py
@@ -42,7 +42,7 @@ def test_softassign_4by4():
     res = softassign(array_a, array_b,
                      remove_zero_col=False,
                      remove_zero_row=False)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -61,7 +61,7 @@ def test_softassign_4by4_loop():
         res = softassign(array_a, array_b,
                          remove_zero_col=False,
                          remove_zero_row=False)
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -82,7 +82,7 @@ def test_softassign_4by4_loop_negative():
             res = softassign(array_a, array_b,
                              remove_zero_row=False,
                              remove_zero_col=False)
-            assert_almost_equal(res["array_u"], perm, decimal=6)
+            assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -99,7 +99,7 @@ def test_softassign_4by4_translate_scale():
                      translate=True, scale=True,
                      remove_zero_row=False,
                      remove_zero_col=False)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -120,7 +120,7 @@ def test_softassign_4by4_translate_scale_loop():
                          array_b,
                          translate=True,
                          scale=True)
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -143,7 +143,7 @@ def test_softassign_4by4_translate_scale_zero_padding():
                      scale=False,
                      remove_zero_row=True,
                      remove_zero_col=True)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -171,7 +171,7 @@ def test_softassign_practical_example():
                      scale=False,
                      remove_zero_row=False,
                      remove_zero_col=False)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -199,7 +199,7 @@ def test_softassign_random_noise():
                      scale=False,
                      remove_zero_row=False,
                      remove_zero_col=False)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
 
 
 def test_softassign_invalid_beta_r():
@@ -228,7 +228,7 @@ def test_softassign_4by4_beta_0():
                      beta_0=1.e-6,
                      translate=False,
                      scale=False)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -247,7 +247,7 @@ def test_softassign_4by4_anneal_steps():
                      iteration_anneal=165,
                      translate=False,
                      scale=False)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
 
@@ -285,7 +285,7 @@ def test_softassign_m_guess():
                      m_guess=m_guess2,
                      translate=False,
                      scale=False)
-    assert_almost_equal(res["array_u"], perm, decimal=6)
+    assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
     # check if initial guess given shape not matching
     with warnings.catch_warnings(record=True) as warn_info:
@@ -298,7 +298,7 @@ def test_softassign_m_guess():
         assert len(warn_info) == 1
         assert not str(warn_info[0].message).startswith("We must specify")
         # check the results
-        assert_almost_equal(res["array_u"], perm, decimal=6)
+        assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
 

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -46,8 +46,8 @@ def test_symmetric_transformed():
     # compute procrustes transformation
     res = symmetric(array_a, array_b, translate=False, scale=False)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
-    assert_almost_equal(res["array_u"], sym_array, decimal=6)
+    assert_almost_equal(res["t"], res["t"].T, decimal=6)
+    assert_almost_equal(res["t"], sym_array, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
@@ -63,7 +63,7 @@ def test_symmetric_scaled_shifted_tranformed():
     # compute procrustes transformation
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
+    assert_almost_equal(res["t"], res["t"].T, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
@@ -81,7 +81,7 @@ def test_symmetric_scaled_shifted_tranformed_4by3():
     # compute procrustes transformation
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
+    assert_almost_equal(res["t"], res["t"].T, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
@@ -99,7 +99,7 @@ def test_symmetric():
     # compute procrustes transformation
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
+    assert_almost_equal(res["t"], res["t"].T, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
@@ -112,7 +112,7 @@ def test_not_full_rank_case():
     # compute procrustes transformation
     res = symmetric(array_a, array_b)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
+    assert_almost_equal(res["t"], res["t"].T, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
@@ -127,7 +127,7 @@ def test_having_zero_singular_case():
     # compute procrustes transformation
     res = symmetric(array_a, array_b)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["array_u"], res["array_u"].T, decimal=6)
+    assert_almost_equal(res["t"], res["t"].T, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
@@ -182,7 +182,7 @@ class TestAgainstNumerical:
         res = symmetric(array_a, array_b)
 
         assert np.abs(res["error"] - desired_func) < 1e-5
-        assert np.all(np.abs(res["array_u"] - desired) < 1e-3)
+        assert np.all(np.abs(res["t"] - desired) < 1e-3)
 
     @pytest.mark.parametrize("nrow", [2, 10, 15])
     def test_fat_rectangular_matrices_with_square_padding(self, nrow):

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -426,20 +426,17 @@ class ProcrustesResult(dict):
 
     Attributes
     ----------
+    error : float
+        The Procrustes (squared Frobenius norm) error.
     new_a : ndarray
         The translated/scaled numpy ndarray :math:`\mathbf{A}`.
     new_b : ndarray
         The translated/scaled numpy ndarray :math:`\mathbf{B}`.
-    array_u : ndarray
-        The right hand side optimum transformation matrix.
-    array_p : ndarray
-        The left hand side transformation matrix for two-sided Procrustes problem with
-        two transformation.
-    array_q : ndarray
-        The right hand side transformation matrix for two-sided Procrustes problem with
-        two transformation.
-    error : float
-        Two-sided permutation Procrustes error.
+    t : ndarray
+        The 2D-array :math:`\mathbf{T}` representing the right-hand-side transformation matrix.
+    s : ndarray, optional
+        The 2D-array :math:`\mathbf{S}` representing the left-hand-side transformation
+        matrix. If set to `None`, the one-sided Procrustes is performed.
 
     """
 

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -228,45 +228,43 @@ def _hide_zero_padding(array_a, remove_zero_col=True, remove_zero_row=True, tol=
     return array_a
 
 
-def compute_error(array_a, array_b, array_u, array_v=None):
-    r"""
-    Return the single- or double- sided Procrustes/norm-squared error.
+def compute_error(a, b, t, s=None):
+    r"""Return the one- or two-sided Procrustes (squared Frobenius norm) error.
 
-    The single sided error is defined as
-
-    .. math::
-       \text{Tr}\left[\left(\mathbf{AU} - \mathbf{B}\right)^\dagger
-                       \left(\mathbf{AU} - \mathbf{B}\right)\right]
-
-    The double sided Procrustes error is defined as
+    The double-sided Procrustes error is defined as
 
     .. math::
+       \|\mathbf{S}\mathbf{A}\mathbf{T} - \mathbf{B}\|_{F}^2 =
        \text{Tr}\left[
-            \left(\mathbf{U}_1^\dagger \mathbf{A}\mathbf{U}_2 - \mathbf{B}\right)^\dagger
-            \left(\mathbf{U}_1^\dagger \mathbf{A}\mathbf{U}_2 - \mathbf{B}\right)\right]
+            \left(\mathbf{S}\mathbf{A}\mathbf{T} - \mathbf{B}\right)^\dagger
+            \left(\mathbf{S}\mathbf{A}\mathbf{T} - \mathbf{B}\right)\right]
+
+    when :math:`\mathbf{S}` is the identity matrix :math:`\mathbf{I}`, this is called the one-sided
+    Procrustes error.
 
     Parameters
     ----------
-    array_a : npdarray
-        The 2D array :math:`A` being transformed.
-    array_b : npdarray
-        The 2D reference array :math:`B`.
-    array_u : ndarray
-        The 2D array representing the transformation :math:`\mathbf{U}`.
-    array_v : ndarray, optional
-        The 2D array representing the transformation :math:`\mathbf{V}`. If provided, it will
-        compute the double-sided Procrustes error. Otherwise, will compute the single-sided
-        Procrustes error.
+    a : ndarray
+        The 2D-array :math:`\mathbf{A}_{m \times n}` which is going to be transformed.
+    b : ndarray
+        The 2D-array :math:`\mathbf{B}_{m \times n}` representing the reference matrix.
+    t : ndarray
+        The 2D-array :math:`\mathbf{T}_{n \times n}` representing the right-hand-side transformation
+        matrix.
+    s : ndarray, optional
+        The 2D-array :math:`\mathbf{S}_{m \times m}` representing the left-hand-side transformation
+        matrix. If set to `None`, the one-sided Procrustes error is computed.
 
     Returns
     -------
     error : float
-        The squared value of the distance between transformed array and reference.
+        The squared Frobenius norm of difference between the transformed array, :math:`\mathbf{S}
+        \mathbf{A}\mathbf{T}`, and the reference array, :math:`\mathbf{B}`.
 
     """
-    array_e = np.dot(array_a, array_u) if array_v is None \
-        else np.dot(np.dot(array_u.T, array_a), array_v)
-    array_e -= array_b
+    # transform matrix A and, subtract B, and then compute the norm
+    array_e = np.dot(a, t) if s is None else np.dot(np.dot(t.T, a), s)
+    array_e -= b
     return np.trace(np.dot(array_e.T, array_e))
 
 

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -262,10 +262,10 @@ def compute_error(a, b, t, s=None):
         \mathbf{A}\mathbf{T}`, and the reference array, :math:`\mathbf{B}`.
 
     """
-    # transform matrix A and, subtract B, and then compute the norm
-    array_e = np.dot(a, t) if s is None else np.dot(np.dot(t.T, a), s)
-    array_e -= b
-    return np.trace(np.dot(array_e.T, array_e))
+    # transform matrix A
+    a_trans = np.dot(a, t) if s is None else np.dot(np.dot(t.T, a), s)
+    # subtract matrix B and compute Frobenius norm squared
+    return np.linalg.norm(a_trans - b, ord=None) ** 2
 
 
 def setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,

--- a/tox.ini
+++ b/tox.ini
@@ -180,10 +180,10 @@ disable=
     R1705,
     # Value XX is unsubscriptable (E1136). this is a open issue of pylint
     # https://github.com/PyCQA/pylint/issues/3139
-    E1136
+    E1136,
     # Used when a name doesn't doesn't fit the naming convention associated to its type
     # (constant, variable, class…).
-    C0103
+    C0103,
 
 [SIMILARITIES]
 min-similarity-lines=5

--- a/tox.ini
+++ b/tox.ini
@@ -181,6 +181,9 @@ disable=
     # Value XX is unsubscriptable (E1136). this is a open issue of pylint
     # https://github.com/PyCQA/pylint/issues/3139
     E1136
+    # Used when a name doesn't doesn't fit the naming convention associated to its type
+    # (constant, variable, class…).
+    C0103
 
 [SIMILARITIES]
 min-similarity-lines=5


### PR DESCRIPTION
The `compute_error` and `ProcrustesResult` are refactored.