### PR TITLE
Fix sphinx building problem

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx>=2.0
 numpydoc>=0.9.0
 sphinx_rtd_theme>=0.4.0
-sphinxcontrib-bibtex>=0.4.2
+sphinxcontrib-bibtex<2.0.0
 sphinx-autoapi>=1.5.1


### PR DESCRIPTION
This PR is mainly about updating the sphinx static website.

- [x] Fix the error due to incompatibility of `sphinx-bibtex` and we fix this problem by forcing it to use 1.0.0 version.

This error is caused by sphinx-bibtex major 2.0.0 release which is incompatible. Using version 1.0.0 can fix this.
For more information, [detailed discussion on `sphinx-bibtex` problem](https://github.com/executablebooks/jupyter-book/issues/1137).
