### PR TITLE
Replace Travis CI badge with GitHub Actions one

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Procrustes
 <a href='https://docs.python.org/3.7/'><img src='https://img.shields.io/badge/python-3.7-blue.svg'></a>
 <a href='https://docs.python.org/3.8/'><img src='https://img.shields.io/badge/python-3.8-blue.svg'></a>
 [![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/)
-[![Build Status](https://travis-ci.com/theochem/procrustes.svg?branch=master)](https://travis-ci.com/theochem/procrustes)
+[![GitHub Actions Status](https://github.com/theochem/procrustes/actions/workflows/testing.yml/badge.svg?branch=master)](https://github.com/theochem/procrustes/actions)
 [![Documentation Status](https://readthedocs.org/projects/procrustes/badge/?version=latest)](https://procrustes.readthedocs.io/en/latest/?badge=latest)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/theochem/procrustes/master?filepath=docs%2Fnotebooks%2F)
 


### PR DESCRIPTION
This is because we are transferring to GitHub Actions and the outdated Travis CI badge is not working due to a negative credit balance. 

For more information on GitHub Actions badge, please see [blog](https://andresand.medium.com/adding-github-action-workflow-status-badge-to-your-repository-22ccea025af6) and [GitHub docs](https://docs.github.com/en/actions/managing-workflow-runs/adding-a-workflow-status-badgebadge_logo).