### PR TITLE
Add testing support for Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Procrustes
 <a href='https://docs.python.org/3.6/'><img src='https://img.shields.io/badge/python-3.6-blue.svg'></a>
 <a href='https://docs.python.org/3.7/'><img src='https://img.shields.io/badge/python-3.7-blue.svg'></a>
 <a href='https://docs.python.org/3.8/'><img src='https://img.shields.io/badge/python-3.8-blue.svg'></a>
+<a href='https://docs.python.org/3.9/'><img src='https://img.shields.io/badge/python-3.9-blue.svg'></a>
 [![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/)
 [![GitHub Actions Status](https://github.com/theochem/procrustes/actions/workflows/testing.yml/badge.svg?branch=master)](https://github.com/theochem/procrustes/actions)
 [![Documentation Status](https://readthedocs.org/projects/procrustes/badge/?version=latest)](https://procrustes.readthedocs.io/en/latest/?badge=latest)

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,10 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38, readme, linters, coverage-report, qa
+    3.9: py39
 
 [tox]
-envlist = py36,py37,py38,readme,linters,coverage-report,qa
+envlist = py36, py37, py38, py39, readme, linters, coverage-report, qa
 
 [testenv]
 deps =


### PR DESCRIPTION
As Python 3.9 becomes a stable release and Python  3.10 is about to come, we should add support of py39. Both the `tox.ini` and `README.md` are updated.

That's all for this small PR.