### PR TITLE
Refactor kopt Module

### DIFF
--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -87,7 +87,7 @@ def kopt_heuristic_single(a, b, p=None, k=3):
     while search:
         search = False
         for perm in it.permutations(np.arange(n), r=k):
-            comb = sorted(perm)
+            comb = tuple(sorted(perm))
             if perm != comb:
                 # row-swap P matrix & compute error
                 perm_p = np.copy(p)
@@ -161,21 +161,22 @@ def kopt_heuristic_double(a, b, p1=None, p2=None, k=3):
     # pylint: disable=too-many-nested-blocks
 
     for perm1 in it.permutations(np.arange(n), r=k):
-        comb1 = sorted(perm1)
+        comb1 = tuple(sorted(perm1))
         for perm2 in it.permutations(np.arange(m), r=k):
-            comb2 = sorted(perm2)
-            # permute rows of matrix P1
-            perm_p1 = np.copy(p1)
-            perm_p1[comb1, :] = perm_p1[perm1, :]
-            # permute rows of matrix P2
-            perm_p2 = np.copy(p2)
-            perm_p2[comb2, :] = perm_p2[perm2, :]
-            # compute error with new matrices & compare
-            perm_error = compute_error(b, a, perm_p1, perm_p2)
-            if perm_error < error:
-                p1, p2, error = perm_p1, perm_p2, perm_error
-                # check whether perfect permutation matrix is found
-                # TODO: smarter threshold based on norm of matrix
-                if error <= 1.0e-8:
-                    break
+            comb2 = tuple(sorted(perm2))
+            if not (perm1 == comb1 and perm2 == comb2):
+                # permute rows of matrix P1
+                perm_p1 = np.copy(p1)
+                perm_p1[comb1, :] = perm_p1[perm1, :]
+                # permute rows of matrix P2
+                perm_p2 = np.copy(p2)
+                perm_p2[comb2, :] = perm_p2[perm2, :]
+                # compute error with new matrices & compare
+                perm_error = compute_error(b, a, perm_p1, perm_p2)
+                if perm_error < error:
+                    p1, p2, error = perm_p1, perm_p2, perm_error
+                    # check whether perfect permutation matrix is found
+                    # TODO: smarter threshold based on norm of matrix
+                    if error <= 1.0e-8:
+                        break
     return p1, p2, error

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -87,7 +87,7 @@ def kopt_heuristic_single(a, b, p=None, k=3):
     return p, error
 
 
-def kopt_heuristic_double(a, b, p=None, q=None, k=3, tol=1.0e-8):
+def kopt_heuristic_double(a, b, p=None, q=None, k=3):
     r"""
     K-opt kopt for regular two-sided permutation Procrustes to improve the accuracy.
 
@@ -101,23 +101,21 @@ def kopt_heuristic_double(a, b, p=None, q=None, k=3, tol=1.0e-8):
     b : ndarray
         The 2D-array :math:`\mathbf{B}` representing the reference matrix.
     p : ndarray, optional
-        The left permutation array which remains to be processed with k-opt local search. Default
-        is the identity matrix with the same shape of array_m.
+        The 2D-array :math:`\mathbf{P}` representing the initial right-hand-side permutation matrix.
+        If `None`, the identity matrix is used.
     q : ndarray, optional
-        The right permutation array which remains to be processed with k-opt local search. Default
-        is the identity matrix with the same shape of array_m.
+        The 2D-array :math:`\mathbf{Q}` representing the initial left-hand-side permutation matrix.
+        If `None`, the identity matrix is used.
     k : int, optional
-        Defines the oder of k-opt heuristic local search. For example, k=3 leads to a local
-        search of 3 items and k=2 only searches for two items locally.
-    tol : float, optional
-        Tolerance value to check if k-opt heuristic converges.
+        The order of the permutation. For example, `k=3` swaps all possible 3-permutations of the
+        given p matrix.
 
     Returns
     -------
     perm_kopt_p : ndarray
-        The left permutation array after optimal heuristic search.
+        The right-hand-side permutation matrix after optimal heuristic search.
     perm_kopt_q : ndarray
-        The right permutation array after optimal heuristic search.
+        The left-hand-side permutation matrix after optimal heuristic search.
     kopt_error : float
         The error distance of two arrays with the updated permutation array.
     """
@@ -149,7 +147,9 @@ def kopt_heuristic_double(a, b, p=None, q=None, k=3, tol=1.0e-8):
                             if e_kopt_new_right < kopt_error:
                                 q = perm_kopt_right
                                 kopt_error = e_kopt_new_right
-                                if kopt_error <= tol:
+                                # check whether perfect permutation matrix is found
+                                # TODO: smarter threshold based on norm of matrix
+                                if kopt_error <= 1.0e-8:
                                     break
 
                 perm_kopt_left[comb_left, :] = perm_kopt_left[comb_perm_left, :]
@@ -157,7 +157,9 @@ def kopt_heuristic_double(a, b, p=None, q=None, k=3, tol=1.0e-8):
                 if e_kopt_new_left < kopt_error:
                     p = perm_kopt_left
                     kopt_error = e_kopt_new_left
-                    if kopt_error <= tol:
+                    # check whether perfect permutation matrix is found
+                    # TODO: smarter threshold based on norm of matrix
+                    if kopt_error <= 1.0e-8:
                         break
 
     return p, q, kopt_error

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -23,7 +23,6 @@
 """K-opt (Greedy) Heuristic Module."""
 
 
-from copy import deepcopy
 import itertools as it
 
 import numpy as np
@@ -91,7 +90,7 @@ def kopt_heuristic_single(a, b, p=None, k=3):
             comb = sorted(perm)
             if perm != comb:
                 # row-swap P matrix & compute error
-                perm_p = deepcopy(p)
+                perm_p = np.copy(p)
                 perm_p[:, comb] = perm_p[:, perm]
                 perm_error = compute_error(a, b, perm_p, perm_p)
                 if perm_error < error:
@@ -166,10 +165,10 @@ def kopt_heuristic_double(a, b, p1=None, p2=None, k=3):
         for perm2 in it.permutations(np.arange(m), r=k):
             comb2 = sorted(perm2)
             # permute rows of matrix P1
-            perm_p1 = deepcopy(p1)
+            perm_p1 = np.copy(p1)
             perm_p1[comb1, :] = perm_p1[perm1, :]
             # permute rows of matrix P2
-            perm_p2 = deepcopy(p2)
+            perm_p2 = np.copy(p2)
             perm_p2[comb2, :] = perm_p2[perm2, :]
             # compute error with new matrices & compare
             perm_error = compute_error(b, a, perm_p1, perm_p2)

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -34,7 +34,7 @@ __all__ = [
 ]
 
 
-def kopt_heuristic_single(a, b, p=None, k=3, tol=1.0e-8):
+def kopt_heuristic_single(a, b, p=None, k=3):
     r"""Compute locally optimal permutation matrix and its error using k-opt heuristic.
 
     Perform k-opt local search with every possible valid combination of the swapping mechanism.
@@ -51,8 +51,6 @@ def kopt_heuristic_single(a, b, p=None, k=3, tol=1.0e-8):
     k : int, optional
         The order of the permutation. For example, `k=3` swaps all possible 3-permutations of the
         given p matrix.
-    tol : float, optional
-        Convergence threshold of the heuristic algorithm.
 
     Returns
     -------
@@ -77,8 +75,10 @@ def kopt_heuristic_single(a, b, p=None, k=3, tol=1.0e-8):
                 error_new = compute_error(a, b, p_new, p_new)
                 if error_new < error:
                     p, error = p_new, error_new
-                    if error <= tol:
-                        break
+                    # check whether perfect permutation matrix is found
+                    # TODO: smarter threshold based on norm of matrix
+                    if error <= 1.0e-8:
+                        return p, error
     return p, error
 
 

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -35,9 +35,17 @@ __all__ = [
 
 
 def kopt_heuristic_single(a, b, p=None, k=3):
-    r"""Compute locally optimal permutation matrix and its error using k-opt heuristic.
+    r"""Find a locally-optimal one-sided permutation matrix using the k-opt (greedy) heuristic.
 
-    Perform k-opt local search with every possible valid combination of the swapping mechanism.
+    .. math::
+       \underbrace{\text{min}}_{\left\{\mathbf{P} \left| {[\mathbf{P}]_{ij} \in \{0, 1\}
+       \atop \sum_{i=1}^n [\mathbf{P}]_{ij} = \sum_{j=1}^n [\mathbf{P}]_{ij} = 1} \right. \right\}}
+       \|\mathbf{P}^\dagger \mathbf{A} \mathbf{P} - \mathbf{B}\|_{F}^2\\
+
+    All possible 2-, ..., k-fold row-permutations of the initial permutation matrix are tried to
+    identify one which gives a lower error. Starting from this updated permutation matrix, the
+    process is repeated until no further k-fold swaps of a given permutation matrix lower the
+    error.
 
     Parameters
     ----------
@@ -88,11 +96,20 @@ def kopt_heuristic_single(a, b, p=None, k=3):
 
 
 def kopt_heuristic_double(a, b, p=None, q=None, k=3):
-    r"""
-    K-opt kopt for regular two-sided permutation Procrustes to improve the accuracy.
+    r"""Find a locally-optimal two-sided permutation matrices using the k-opt (greedy) heuristic.
 
-    Perform k-opt local search with every possible valid combination of the swapping mechanism for
-    regular 2-sided permutation Procrustes.
+    .. math::
+        &\underbrace{\text{min}}_{\left\{\mathbf{P}_1,\mathbf{P}_2 \left|
+        {[\mathbf{P}_1]_{ij} \in \{0, 1\} \atop \sum_{i=1}^n [\mathbf{P}_1]_{ij} = \sum_{j=1}^n [
+        \mathbf{P}_1]_{ij} = 1} \atop {[\mathbf{P}_2]_{ij} \in \{0, 1\} \atop \sum_{i=1}^n [
+        \mathbf{P}_2]_{ij} = \sum_{j=1}^n [\mathbf{P}_2]_{ij} = 1} \right. \right\}}
+            \|\mathbf{P}_1 \mathbf{A} \mathbf{P}_2 - \mathbf{B}\|_{F}^2\\
+
+    All possible 2-, ..., k-fold permutations of the initial permutation matrices are tried to
+    identify ones which give a lower error. This corresponds to column-swaps for :math:`\mathbf{
+    P}_1` and row-swaps for :math:`\mathbf{P}_2`. Starting from these updated permutation
+    matrices, the process is repeated until no further k-fold swaps of either permutation matrix
+    lower the error.
 
     Parameters
     ----------

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -66,6 +66,7 @@ def kopt_heuristic_single(a, b, p=None, k=3):
         p = np.identity(np.shape(a)[0])
     # compute 2-sided permutation error of the initial p matrix
     error = compute_error(a, b, p, p)
+    # pylint: disable=too-many-nested-blocks
     # swap rows and columns until the permutation matrix is not improved
     search = True
     while search:

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -34,28 +34,28 @@ __all__ = [
 ]
 
 
-def kopt_heuristic_single(array_a, array_b, ref_error,
-                          perm=None, kopt_k=3, kopt_tol=1.e-8):
+def kopt_heuristic_single(a, b, ref_error, p=None, k=3, tol=1.0e-8):
     r"""K-opt heuristic to improve the accuracy for two-sided permutation with one transformation.
 
     Perform k-opt local search with every possible valid combination of the swapping mechanism.
 
     Parameters
     ----------
-    array_a : ndarray
-        The array to be permuted.
-    array_b : ndarray
-        The reference array.
+    a : ndarray
+        The 2D-array :math:`\mathbf{A}` which is going to be transformed.
+    b : ndarray
+        The 2D-array :math:`\mathbf{B}` representing the reference matrix.
     ref_error : float
         The reference error value.
-    perm : ndarray, optional
+    p : ndarray, optional
+        The 2D-array :math:`\mathbf{P}` representing the initial permutation matrix.
         The permutation array which remains to be processed with k-opt local search. Default is the
-        identity matrix with the same shape of array_a.
-    kopt_k : int, optional
-        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
-        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
-    kopt_tol : float, optional
-        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
+        identity matrix with the same shape of a.
+    k : int, optional
+        Defines the oder of k-opt heuristic local search. For example, k=3 leads to a local
+        search of 3 items and k=2 only searches for two items locally.
+    tol : float, optional
+        Tolerance value to check if k-opt heuristic converges.
 
     Returns
     -------
@@ -64,31 +64,29 @@ def kopt_heuristic_single(array_a, array_b, ref_error,
     kopt_error : float
         The error distance of two arrays with the updated permutation array.
     """
-    if kopt_k < 2:
-        raise ValueError("Kopt_k value must be a integer greater than 2.")
-    # if perm is not specified, use the identity matrix as default
-    if perm is None:
-        perm = np.identity(np.shape(array_a)[0])
-    num_row = perm.shape[0]
+    if k < 2 or not isinstance(k, int):
+        raise ValueError(f"Argument k must be a integer greater than 2. Given k={k}")
+    # assign p to be an identity array, if not specified
+    if p is None:
+        p = np.identity(np.shape(a)[0])
+    num_row = p.shape[0]
     kopt_error = ref_error
     # all the possible row-wise permutations
-    for comb in it.combinations(np.arange(num_row), r=kopt_k):
-        for comb_perm in it.permutations(comb, r=kopt_k):
+    for comb in it.combinations(np.arange(num_row), r=k):
+        for comb_perm in it.permutations(comb, r=k):
             if comb_perm != comb:
-                perm_kopt = deepcopy(perm)
+                perm_kopt = deepcopy(p)
                 perm_kopt[comb, :] = perm_kopt[comb_perm, :]
-                e_kopt_new = compute_error(array_a, array_b, perm_kopt, perm_kopt)
+                e_kopt_new = compute_error(a, b, perm_kopt, perm_kopt)
                 if e_kopt_new < kopt_error:
-                    perm = perm_kopt
+                    p = perm_kopt
                     kopt_error = e_kopt_new
-                    if kopt_error <= kopt_tol:
+                    if kopt_error <= tol:
                         break
-    return perm, kopt_error
+    return p, kopt_error
 
 
-def kopt_heuristic_double(array_m, array_n, ref_error,
-                          perm_p=None, perm_q=None,
-                          kopt_k=3, kopt_tol=1.e-8):
+def kopt_heuristic_double(a, b, ref_error, p=None, q=None, k=3, tol=1.0e-8):
     r"""
     K-opt kopt for regular two-sided permutation Procrustes to improve the accuracy.
 
@@ -97,23 +95,23 @@ def kopt_heuristic_double(array_m, array_n, ref_error,
 
     Parameters
     ----------
-    array_m : ndarray
-        The array to be permuted.
-    array_n : ndarray
-        The reference array.
+    a : ndarray
+        The 2D-array :math:`\mathbf{A}` which is going to be transformed.
+    b : ndarray
+        The 2D-array :math:`\mathbf{B}` representing the reference matrix.
     ref_error : float
         The reference error value.
-    perm_p : ndarray, optional
+    p : ndarray, optional
         The left permutation array which remains to be processed with k-opt local search. Default
         is the identity matrix with the same shape of array_m.
-    perm_q : ndarray, optional
+    q : ndarray, optional
         The right permutation array which remains to be processed with k-opt local search. Default
         is the identity matrix with the same shape of array_m.
-    kopt_k : int, optional
-        Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
-        search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
-    kopt_tol : float, optional
-        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
+    k : int, optional
+        Defines the oder of k-opt heuristic local search. For example, k=3 leads to a local
+        search of 3 items and k=2 only searches for two items locally.
+    tol : float, optional
+        Tolerance value to check if k-opt heuristic converges.
 
     Returns
     -------
@@ -124,44 +122,43 @@ def kopt_heuristic_double(array_m, array_n, ref_error,
     kopt_error : float
         The error distance of two arrays with the updated permutation array.
     """
-    if kopt_k < 2:
-        raise ValueError("Kopt_k value must be a integer greater than 2.")
-    # if perm_p is not specified, use the identity matrix as default
-    if perm_p is None:
-        perm_p = np.identity(np.shape(array_m)[0])
-    # if perm_p is not specified, use the identity matrix as default
-    if perm_q is None:
-        perm_q = np.identity(np.shape(array_m)[0])
+    if k < 2 or not isinstance(k, int):
+        raise ValueError(f"Argument k must be a integer greater than 2. Given k={k}")
+    # assign p & q to be an identity arrays, if not specified
+    if p is None:
+        p = np.identity(np.shape(a)[0])
+    if q is None:
+        q = np.identity(np.shape(a)[0])
 
-    num_row_left = perm_p.shape[0]
-    num_row_right = perm_q.shape[0]
+    num_row_left = p.shape[0]
+    num_row_right = q.shape[0]
     kopt_error = ref_error
     # the left hand side permutation
     # pylint: disable=too-many-nested-blocks
-    for comb_left in it.combinations(np.arange(num_row_left), r=kopt_k):
-        for comb_perm_left in it.permutations(comb_left, r=kopt_k):
+    for comb_left in it.combinations(np.arange(num_row_left), r=k):
+        for comb_perm_left in it.permutations(comb_left, r=k):
             if comb_perm_left != comb_left:
-                perm_kopt_left = deepcopy(perm_p)
+                perm_kopt_left = deepcopy(p)
                 # the right hand side permutation
-                for comb_right in it.combinations(np.arange(num_row_right), r=kopt_k):
-                    for comb_perm_right in it.permutations(comb_right, r=kopt_k):
+                for comb_right in it.combinations(np.arange(num_row_right), r=k):
+                    for comb_perm_right in it.permutations(comb_right, r=k):
                         if comb_perm_right != comb_right:
-                            perm_kopt_right = deepcopy(perm_q)
+                            perm_kopt_right = deepcopy(q)
                             perm_kopt_right[comb_right, :] = perm_kopt_right[comb_perm_right, :]
-                            e_kopt_new_right = compute_error(array_n, array_m, perm_p.T,
+                            e_kopt_new_right = compute_error(b, a, p.T,
                                                              perm_kopt_right)
                             if e_kopt_new_right < kopt_error:
-                                perm_q = perm_kopt_right
+                                q = perm_kopt_right
                                 kopt_error = e_kopt_new_right
-                                if kopt_error <= kopt_tol:
+                                if kopt_error <= tol:
                                     break
 
                 perm_kopt_left[comb_left, :] = perm_kopt_left[comb_perm_left, :]
-                e_kopt_new_left = compute_error(array_n, array_m, perm_kopt_left.T, perm_q)
+                e_kopt_new_left = compute_error(b, a, perm_kopt_left.T, q)
                 if e_kopt_new_left < kopt_error:
-                    perm_p = perm_kopt_left
+                    p = perm_kopt_left
                     kopt_error = e_kopt_new_left
-                    if kopt_error <= kopt_tol:
+                    if kopt_error <= tol:
                         break
 
-    return perm_p, perm_q, kopt_error
+    return p, q, kopt_error

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -64,21 +64,25 @@ def kopt_heuristic_single(a, b, p=None, k=3):
     # assign p to be an identity array, if not specified
     if p is None:
         p = np.identity(np.shape(a)[0])
-    num_row = p.shape[0]
+    # compute 2-sided permutation error of the initial p matrix
     error = compute_error(a, b, p, p)
-    # all the possible row-wise permutations
-    for comb in it.combinations(np.arange(num_row), r=k):
-        for comb_perm in it.permutations(comb, r=k):
-            if comb_perm != comb:
-                p_new = deepcopy(p)
-                p_new[comb, :] = p_new[comb_perm, :]
-                error_new = compute_error(a, b, p_new, p_new)
-                if error_new < error:
-                    p, error = p_new, error_new
-                    # check whether perfect permutation matrix is found
-                    # TODO: smarter threshold based on norm of matrix
-                    if error <= 1.0e-8:
-                        return p, error
+    # swap rows and columns until the permutation matrix is not improved
+    search = True
+    while search:
+        search = False
+        for comb in it.combinations(np.arange(p.shape[0]), r=k):
+            for comb_perm in it.permutations(comb, r=k):
+                if comb_perm != comb:
+                    p_new = deepcopy(p)
+                    p_new[comb, :] = p_new[comb_perm, :]
+                    error_new = compute_error(a, b, p_new, p_new)
+                    if error_new < error:
+                        search = True
+                        p, error = p_new, error_new
+                        # check whether perfect permutation matrix is found
+                        # TODO: smarter threshold based on norm of matrix
+                        if error <= 1.0e-8:
+                            return p, error
     return p, error
 
 

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -425,7 +425,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
         # perform k-opt heuristic search twice
         if kopt:
             array_p, array_q, error = kopt_heuristic_double(a=array_m, b=array_n, p=array_p,
-                                                            q=array_q, k=kopt_k, tol=kopt_tol)
+                                                            q=array_q, k=kopt_k)
         # return array_m, array_n, array_p, array_q, error
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_q, s=array_p)
     else:

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -396,12 +396,12 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             # Compute the permutation matrix by iterations
             array_u = _compute_transform(new_a_positive, new_b_positive,
                                          guess, tol, iteration)
-            error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
             # k-opt heuristic
             if kopt:
                 array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
-                                                       ref_error=error, p=array_u, k=kopt_k,
-                                                       tol=kopt_tol)
+                                                       p=array_u, k=kopt_k, tol=kopt_tol)
+            else:
+                error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
         # algorithm for directed graph matching problem
         else:
             # the initial guess
@@ -409,12 +409,12 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             # Compute the permutation matrix by iterations
             array_u = _compute_transform_directed(new_a_positive, new_b_positive,
                                                   guess, tol, iteration)
-            error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
             # k-opt heuristic
             if kopt:
                 array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
-                                                       ref_error=error, p=array_u, k=kopt_k,
-                                                       tol=kopt_tol)
+                                                       p=array_u, k=kopt_k, tol=kopt_tol)
+            else:
+                error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u, s=None)
 
     # Do regular computation
@@ -424,9 +424,8 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
         array_p, array_q, error = _2sided_regular(array_m, array_n, tol, iteration)
         # perform k-opt heuristic search twice
         if kopt:
-            array_p, array_q, error = kopt_heuristic_double(a=array_m, b=array_n, ref_error=error,
-                                                            p=array_p, q=array_q, k=kopt_k,
-                                                            tol=kopt_tol)
+            array_p, array_q, error = kopt_heuristic_double(a=array_m, b=array_n, p=array_p,
+                                                            q=array_q, k=kopt_k, tol=kopt_tol)
         # return array_m, array_n, array_p, array_q, error
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_q, s=array_p)
     else:

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -421,8 +421,8 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
         array_p, array_q, error = _2sided_regular(array_m, array_n, tol, iteration)
         # perform k-opt heuristic search twice
         if kopt:
-            array_p, array_q, error = kopt_heuristic_double(a=array_m, b=array_n, p=array_p,
-                                                            q=array_q, k=kopt_k)
+            array_p, array_q, error = kopt_heuristic_double(a=array_m, b=array_n, p1=array_p,
+                                                            p2=array_q, k=kopt_k)
         # return array_m, array_n, array_p, array_q, error
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_q, s=array_p)
     else:

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -140,7 +140,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
                        pad_mode="row-col", translate=False, scale=False,
                        mode="normal1", check_finite=True, iteration=500,
                        add_noise=False, tol=1.0e-8, kopt=False, kopt_k=3,
-                       kopt_tol=1.e-8, weight=None):
+                       weight=None):
     r"""Double sided permutation Procrustes.
 
     Parameters
@@ -213,9 +213,6 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
     kopt_k : int, optional
         Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
         search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
-    kopt_tol : float, optional
-        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
-
 
     Returns
     -------

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -399,12 +399,9 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
             # k-opt heuristic
             if kopt:
-                array_u, error = kopt_heuristic_single(array_a=new_a_positive,
-                                                       array_b=new_b_positive,
-                                                       ref_error=error,
-                                                       perm=array_u,
-                                                       kopt_k=kopt_k,
-                                                       kopt_tol=kopt_tol)
+                array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
+                                                       ref_error=error, p=array_u, k=kopt_k,
+                                                       tol=kopt_tol)
         # algorithm for directed graph matching problem
         else:
             # the initial guess
@@ -415,12 +412,9 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
             # k-opt heuristic
             if kopt:
-                array_u, error = kopt_heuristic_single(array_a=new_a_positive,
-                                                       array_b=new_b_positive,
-                                                       ref_error=error,
-                                                       perm=array_u,
-                                                       kopt_k=kopt_k,
-                                                       kopt_tol=kopt_tol)
+                array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
+                                                       ref_error=error, p=array_u, k=kopt_k,
+                                                       tol=kopt_tol)
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u, s=None)
 
     # Do regular computation
@@ -430,13 +424,9 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
         array_p, array_q, error = _2sided_regular(array_m, array_n, tol, iteration)
         # perform k-opt heuristic search twice
         if kopt:
-            array_p, array_q, error = kopt_heuristic_double(array_m=array_m,
-                                                            array_n=array_n,
-                                                            ref_error=error,
-                                                            perm_p=array_p,
-                                                            perm_q=array_q,
-                                                            kopt_k=kopt_k,
-                                                            kopt_tol=kopt_tol)
+            array_p, array_q, error = kopt_heuristic_double(a=array_m, b=array_n, ref_error=error,
+                                                            p=array_p, q=array_q, k=kopt_k,
+                                                            tol=kopt_tol)
         # return array_m, array_n, array_p, array_q, error
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_q, s=array_p)
     else:

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -399,7 +399,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             # k-opt heuristic
             if kopt:
                 array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
-                                                       p=array_u, k=kopt_k, tol=kopt_tol)
+                                                       p=array_u, k=kopt_k)
             else:
                 error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
         # algorithm for directed graph matching problem
@@ -412,7 +412,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
             # k-opt heuristic
             if kopt:
                 array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
-                                                       p=array_u, k=kopt_k, tol=kopt_tol)
+                                                       p=array_u, k=kopt_k)
             else:
                 error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u, s=None)

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -305,11 +305,11 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
 
     # Compute the error
     array_m = permutation(np.eye(array_m.shape[0]), array_m)["t"]
-    error = compute_error(new_a, new_b, array_m, array_m)
     # k-opt heuristic
     if kopt:
-        array_m, error = kopt_heuristic_single(a=new_a, b=new_b, ref_error=error, p=array_m,
-                                               k=kopt_k, tol=kopt_tol)
+        array_m, error = kopt_heuristic_single(a=new_a, b=new_b, p=array_m, k=kopt_k, tol=kopt_tol)
+    else:
+        error = compute_error(new_a, new_b, array_m, array_m)
     return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_m, s=None)
 
 

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -41,7 +41,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
                pad_mode='row-col', remove_zero_col=True, remove_zero_row=True,
                translate=False, scale=False, check_finite=True, adapted=True,
                beta_0=None, m_guess=None, iteration_anneal=None, kopt=False,
-               kopt_k=3, kopt_tol=1.e-8, weight=None):
+               kopt_k=3, weight=None):
     r"""
     Find the transformation matrix for 2-sided permutation Procrustes with softassign algorithm.
 
@@ -127,8 +127,6 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
     kopt_k : int, optional
         Defines the oder of k-opt heuristic local search. For example, kopt_k=3 leads to a local
         search of 3 items and kopt_k=2 only searches for two items locally. Default=3.
-    kopt_tol : float, optional
-        Tolerance value to check if k-opt heuristic converges. Default=1.e-8.
     weight : ndarray
         The weighting matrix. Default=None.
 

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -307,7 +307,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
     array_m = permutation(np.eye(array_m.shape[0]), array_m)["t"]
     # k-opt heuristic
     if kopt:
-        array_m, error = kopt_heuristic_single(a=new_a, b=new_b, p=array_m, k=kopt_k, tol=kopt_tol)
+        array_m, error = kopt_heuristic_single(a=new_a, b=new_b, p=array_m, k=kopt_k)
     else:
         error = compute_error(new_a, new_b, array_m, array_m)
     return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_m, s=None)

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -308,12 +308,8 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
     error = compute_error(new_a, new_b, array_m, array_m)
     # k-opt heuristic
     if kopt:
-        array_m, error = kopt_heuristic_single(array_a=new_a,
-                                               array_b=new_b,
-                                               ref_error=error,
-                                               perm=array_m,
-                                               kopt_k=kopt_k,
-                                               kopt_tol=kopt_tol)
+        array_m, error = kopt_heuristic_single(a=new_a, b=new_b, ref_error=error, p=array_m,
+                                               k=kopt_k, tol=kopt_tol)
     return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_m, s=None)
 
 

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -79,8 +79,7 @@ def test_kopt_heuristic_double():
                             [0., 1., 0.]])
     error = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
     perm_left, perm_right, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p=perm1_shuff,
-                                                              q=perm2_shuff, k=4, tol=1.e-8)
-    _, _, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p=perm_left, q=perm_right, k=3,
-                                             tol=1.e-8)
+                                                              q=perm2_shuff, k=4)
+    _, _, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p=perm_left, q=perm_right, k=3)
     assert kopt_error <= error
     assert kopt_error == 0

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -51,13 +51,12 @@ def test_kopt_heuristic_single():
                            [0, 0, 0, 0, 1],
                            [1, 0, 0, 0, 0]])
     error_old = compute_error(arr_a, arr_b, perm_guess, perm_guess)
-    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, error_old,
-                                             perm_guess, 3, kopt_tol=1.e-8)
+    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, error_old, perm_guess, 3, tol=1.e-8)
     assert_equal(perm, perm_exact)
     assert kopt_error == 0
     # test the error exceptions
     assert_raises(ValueError, kopt_heuristic_single, arr_a,
-                  arr_b, error_old, perm_guess, 1, kopt_tol=1.e-8)
+                  arr_b, error_old, perm_guess, 1, tol=1.e-8)
 
 
 def test_kopt_heuristic_double():
@@ -81,13 +80,10 @@ def test_kopt_heuristic_double():
                             [0., 0., 1.],
                             [0., 1., 0.]])
     error = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
-    perm_left, perm_right, kopt_error = kopt_heuristic_double(perm_p=perm1_shuff,
-                                                              perm_q=perm2_shuff,
-                                                              array_m=arr_a, array_n=arr_b,
-                                                              ref_error=error, kopt_k=4,
-                                                              kopt_tol=1.e-8)
-    _, _, kopt_error = kopt_heuristic_double(perm_p=perm_left, perm_q=perm_right,
-                                             array_m=arr_a, array_n=arr_b,
-                                             ref_error=error, kopt_k=3, kopt_tol=1.e-8)
+    perm_left, perm_right, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, ref_error=error,
+                                                              p=perm1_shuff, q=perm2_shuff, k=4,
+                                                              tol=1.e-8)
+    _, _, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, ref_error=error, p=perm_left,
+                                             q=perm_right, k=3, tol=1.e-8)
     assert kopt_error <= error
     assert kopt_error == 0

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -51,11 +51,11 @@ def test_kopt_heuristic_single():
                            [0, 0, 0, 0, 1],
                            [1, 0, 0, 0, 0]])
     error_old = compute_error(arr_a, arr_b, perm_guess, perm_guess)
-    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, perm_guess, 3, tol=1.e-8)
+    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, perm_guess, 3)
     assert_equal(perm, perm_exact)
     assert kopt_error == 0
     # test the error exceptions
-    assert_raises(ValueError, kopt_heuristic_single, arr_a, arr_b, perm_guess, 1, tol=1.e-8)
+    assert_raises(ValueError, kopt_heuristic_single, arr_a, arr_b, perm_guess, 1)
 
 
 def test_kopt_heuristic_double():

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -78,8 +78,8 @@ def test_kopt_heuristic_double():
                             [0., 0., 1.],
                             [0., 1., 0.]])
     error = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
-    perm_left, perm_right, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p=perm1_shuff,
-                                                              q=perm2_shuff, k=4)
-    _, _, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p=perm_left, q=perm_right, k=3)
+    perm_left, perm_right, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p1=perm1_shuff,
+                                                              p2=perm2_shuff, k=4)
+    _, _, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p1=perm_left, p2=perm_right, k=3)
     assert kopt_error <= error
     assert kopt_error == 0

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -51,12 +51,11 @@ def test_kopt_heuristic_single():
                            [0, 0, 0, 0, 1],
                            [1, 0, 0, 0, 0]])
     error_old = compute_error(arr_a, arr_b, perm_guess, perm_guess)
-    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, error_old, perm_guess, 3, tol=1.e-8)
+    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, perm_guess, 3, tol=1.e-8)
     assert_equal(perm, perm_exact)
     assert kopt_error == 0
     # test the error exceptions
-    assert_raises(ValueError, kopt_heuristic_single, arr_a,
-                  arr_b, error_old, perm_guess, 1, tol=1.e-8)
+    assert_raises(ValueError, kopt_heuristic_single, arr_a, arr_b, perm_guess, 1, tol=1.e-8)
 
 
 def test_kopt_heuristic_double():
@@ -80,10 +79,9 @@ def test_kopt_heuristic_double():
                             [0., 0., 1.],
                             [0., 1., 0.]])
     error = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
-    perm_left, perm_right, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, ref_error=error,
-                                                              p=perm1_shuff, q=perm2_shuff, k=4,
-                                                              tol=1.e-8)
-    _, _, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, ref_error=error, p=perm_left,
-                                             q=perm_right, k=3, tol=1.e-8)
+    perm_left, perm_right, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p=perm1_shuff,
+                                                              q=perm2_shuff, k=4, tol=1.e-8)
+    _, _, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p=perm_left, q=perm_right, k=3,
+                                             tol=1.e-8)
     assert kopt_error <= error
     assert kopt_error == 0

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -50,7 +50,6 @@ def test_kopt_heuristic_single():
                            [0, 0, 1, 0, 0],
                            [0, 0, 0, 0, 1],
                            [1, 0, 0, 0, 0]])
-    error_old = compute_error(arr_a, arr_b, perm_guess, perm_guess)
     perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, perm_guess, 3)
     assert_equal(perm, perm_exact)
     assert kopt_error == 0


### PR DESCRIPTION
This refactors the `kopt` module. I removed the `ref_error` argument because the initial permutation matrix is given, so it can be used to compute the initial error. It is easier to compute it internally than clarify it in the documentation and have the user pre-compute the initial error. Also, the user can erroneously provide an error that does not match the initial permutation matrix. This is how I understand/see things, so please feel free to let me know if anything is missing.

I had a few questions that I will raise in this PR.