### PR TITLE
Make 2-sided Procrustes error match |SAT-B|

### DIFF
--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -80,7 +80,7 @@ def kopt_heuristic_single(a, b, p=None, k=3):
     if p is None:
         p = np.identity(n)
     # compute 2-sided permutation error of the initial p matrix
-    error = compute_error(a, b, p, p)
+    error = compute_error(a, b, p, p.T)
     # pylint: disable=too-many-nested-blocks
     # swap rows and columns until the permutation matrix is not improved
     search = True
@@ -92,7 +92,7 @@ def kopt_heuristic_single(a, b, p=None, k=3):
                 # row-swap P matrix & compute error
                 perm_p = np.copy(p)
                 perm_p[:, comb] = perm_p[:, perm]
-                perm_error = compute_error(a, b, perm_p, perm_p)
+                perm_error = compute_error(a, b, perm_p, perm_p.T)
                 if perm_error < error:
                     search = True
                     p, error = perm_p, perm_error
@@ -157,7 +157,7 @@ def kopt_heuristic_double(a, b, p1=None, p2=None, k=3):
         p2 = np.identity(m)
 
     # compute 2-sided permutation error of the initial P & Q matrices
-    error = compute_error(a, b, p1, p2)
+    error = compute_error(a, b, p2, p1.T)
     # pylint: disable=too-many-nested-blocks
 
     for perm1 in it.permutations(np.arange(n), r=k):
@@ -172,7 +172,7 @@ def kopt_heuristic_double(a, b, p1=None, p2=None, k=3):
                 perm_p2 = np.copy(p2)
                 perm_p2[comb2, :] = perm_p2[perm2, :]
                 # compute error with new matrices & compare
-                perm_error = compute_error(b, a, perm_p1, perm_p2)
+                perm_error = compute_error(b, a, perm_p2, perm_p1.T)
                 if perm_error < error:
                     p1, p2, error = perm_p1, perm_p2, perm_error
                     # check whether perfect permutation matrix is found

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -336,13 +336,13 @@ def orthogonal_2sided(
         _, ub = np.linalg.eigh(new_b)
         u_opt = np.dot(ua, ub.T)
         # compute one-sided error
-        error = compute_error(new_a, new_b, u_opt, u_opt)
-        return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=u_opt, s=u_opt)
+        error = compute_error(new_a, new_b, u_opt, u_opt.T)
+        return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=u_opt, s=u_opt.T)
 
     # two-sided orthogonal Procrustes with two-transformations
     ua, _, vta = np.linalg.svd(new_a)
     ub, _, vtb = np.linalg.svd(new_b)
     u_opt1 = np.dot(ua, ub.T)
     u_opt2 = np.dot(vta.T, vtb)
-    error = compute_error(new_a, new_b, u_opt1, u_opt2)
-    return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=u_opt2, s=u_opt1)
+    error = compute_error(new_a, new_b, u_opt2, u_opt1.T)
+    return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=u_opt2, s=u_opt1.T)

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -398,7 +398,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
                 array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
                                                        p=array_u, k=kopt_k)
             else:
-                error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
+                error = compute_error(new_a_positive, new_b_positive, array_u, array_u.T)
         # algorithm for directed graph matching problem
         else:
             # the initial guess
@@ -411,7 +411,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
                 array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
                                                        p=array_u, k=kopt_k)
             else:
-                error = compute_error(new_a_positive, new_b_positive, array_u, array_u)
+                error = compute_error(new_a_positive, new_b_positive, array_u, array_u.T)
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u, s=None)
 
     # Do regular computation
@@ -441,7 +441,7 @@ def _2sided_regular(array_m, array_n, tol, iteration):
     array_p1 = np.eye(array_m.shape[0], array_m.shape[0])
     # Initial guess for Q
     array_q1 = _2sided_hungarian(np.dot(array_n.T, array_m))
-    error1 = compute_error(array_n, array_m, array_p1.T, array_q1)
+    error1 = compute_error(array_n, array_m, array_q1, array_p1)
     step1 = 0
 
     # while loop for the original algorithm
@@ -451,12 +451,12 @@ def _2sided_regular(array_m, array_n, tol, iteration):
         array_p1 = _2sided_hungarian(np.dot(np.dot(array_n, array_q1), array_m.T))
         array_p1 = np.transpose(array_p1)
         # Update the error
-        error1 = compute_error(array_n, array_m, array_p1.T, array_q1)
+        error1 = compute_error(array_n, array_m, array_q1, array_p1)
         if error1 > tol:
             # Update Q
             array_q1 = _2sided_hungarian(np.dot(np.dot(array_n.T, array_p1.T), array_m))
             # Update the error
-            error1 = compute_error(array_n, array_m, array_p1.T, array_q1)
+            error1 = compute_error(array_n, array_m, array_q1, array_p1)
         else:
             break
 
@@ -469,7 +469,7 @@ def _2sided_regular(array_m, array_n, tol, iteration):
     # Initial guess for P
     array_p2 = _2sided_hungarian(np.dot(array_n, array_m.T))
     array_p2 = np.transpose(array_p2)
-    error2 = compute_error(array_n, array_m, array_p2.T, array_q2)
+    error2 = compute_error(array_n, array_m, array_q2, array_p2)
     step2 = 0
 
     # while loop for the original algorithm
@@ -477,12 +477,12 @@ def _2sided_regular(array_m, array_n, tol, iteration):
         # Update Q
         array_q2 = _2sided_hungarian(np.dot(np.dot(array_n.T, array_p2.T), array_m))
         # Update the error
-        error2 = compute_error(array_n, array_m, array_p2.T, array_q1)
+        error2 = compute_error(array_n, array_m, array_q1, array_p2)
         if error2 > tol:
             array_p2 = _2sided_hungarian(np.dot(np.dot(array_n, array_q2), array_m.T))
             array_p2 = np.transpose(array_p2)
             # Update the error
-            error2 = compute_error(array_n, array_m, array_p2.T, array_q2)
+            error2 = compute_error(array_n, array_m, array_q2, array_p2)
             step2 += 1
         else:
             break
@@ -789,8 +789,8 @@ def permutation_2sided_explicit(array_a, array_b,
         size = np.shape(new_a)[1]
         perm2 = np.zeros((size, size))
         perm2[np.arange(size), comb] = 1
-        perm_error2 = compute_error(new_a, new_b, perm2, perm2)
+        perm_error2 = compute_error(new_a, new_b, perm2, perm2.T)
         if perm_error2 < perm_error1:
             perm_error1 = perm_error2
             perm1 = perm2
-    return ProcrustesResult(error=perm_error1, new_a=new_a, new_b=new_b, t=perm1, s=None)
+    return ProcrustesResult(error=perm_error1, new_a=new_a, new_b=new_b, t=perm1, s=perm1.T)

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -307,7 +307,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
     if kopt:
         array_m, error = kopt_heuristic_single(a=new_a, b=new_b, p=array_m, k=kopt_k)
     else:
-        error = compute_error(new_a, new_b, array_m, array_m)
+        error = compute_error(new_a, new_b, array_m, array_m.T)
     return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_m, s=None)
 
 

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -77,7 +77,7 @@ def test_kopt_heuristic_double():
     perm2_shuff = np.array([[1., 0., 0.],
                             [0., 0., 1.],
                             [0., 1., 0.]])
-    error = compute_error(arr_b, arr_a, perm1_shuff.T, perm2_shuff)
+    error = compute_error(arr_b, arr_a, perm2_shuff, perm1_shuff.T)
     perm_left, perm_right, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p1=perm1_shuff,
                                                               p2=perm2_shuff, k=4)
     _, _, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p1=perm_left, p2=perm_right, k=3)

--- a/procrustes/utils.py
+++ b/procrustes/utils.py
@@ -262,8 +262,8 @@ def compute_error(a, b, t, s=None):
         \mathbf{A}\mathbf{T}`, and the reference array, :math:`\mathbf{B}`.
 
     """
-    # transform matrix A
-    a_trans = np.dot(a, t) if s is None else np.dot(np.dot(t.T, a), s)
+    # transform matrix A to either AT or SAT
+    a_trans = np.dot(a, t) if s is None else np.dot(np.dot(s, a), t)
     # subtract matrix B and compute Frobenius norm squared
     return np.linalg.norm(a_trans - b, ord=None) ** 2
 


### PR DESCRIPTION
The `compute_error` was computing the norm of `AT-B` when given one matrix (which was fine) but `T.transpose A S - B` when given two matrices (which is not right), because:

1. The T matrix is expected to always be the right-hand-side transformation 
2. The S matrix is the left-hand-side transformation (and is not supposed to be transposed when computing the |SAT-B|)

These inconsistencies are fixed and the code now matches the `compute_error` documentation.