### PR TITLE
Refactor test symmetric.py

### DIFF
--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -24,6 +24,7 @@
 
 import numpy as np
 from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
+from scipy.linalg import pinv
 
 
 def generic(
@@ -104,9 +105,7 @@ def generic(
         a, b, unpad_col, unpad_row, pad, translate, scale, check_finite, weight,
     )
     # compute the generic solution
-    # set a smarter default for small singular values cutoff
-    rcond = 1.0e-15 * new_a.shape[-1]
-    a_inv = np.linalg.pinv(np.dot(new_a.T, new_a), rcond=rcond)
+    a_inv = pinv(np.dot(new_a.T, new_a))
     array_x = np.linalg.multi_dot([a_inv, new_a.T, new_b])
     # compute one-sided error
     e_opt = compute_error(new_a, new_b, array_x)

--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -104,7 +104,9 @@ def generic(
         a, b, unpad_col, unpad_row, pad, translate, scale, check_finite, weight,
     )
     # compute the generic solution
-    a_inv = np.linalg.pinv(np.dot(new_a.T, new_a))
+    # set a smarter default for small singular values cutoff
+    rcond = 1.0e-15 * new_a.shape[-1]
+    a_inv = np.linalg.pinv(np.dot(new_a.T, new_a), rcond=rcond)
     array_x = np.linalg.multi_dot([a_inv, new_a.T, new_b])
     # compute one-sided error
     e_opt = compute_error(new_a, new_b, array_x)

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -162,12 +162,6 @@ def symmetric(
     if (new_a.shape[0] < new_a.shape[1]) or (new_b.shape[0] < new_b.shape[1]):
         new_a, new_b = _zero_padding(new_a, new_b, "square")
 
-    # if new_a.shape[0] < new_a.shape[1]:
-    #     raise ValueError(f"Shape of A {new_a.shape}=(m, n) needs to satisfy m >= n.")
-    #
-    # if new_b.shape[0] < new_b.shape[1]:
-    #     raise ValueError(f"Shape of B {new_b.shape}=(m, n) needs to satisfy m >= n.")
-
     # compute SVD of A
     u, s, vt = np.linalg.svd(new_a)
 

--- a/procrustes/test/common.py
+++ b/procrustes/test/common.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# The Procrustes library provides a set of functions for transforming
+# a matrix to make it as similar as possible to a target matrix.
+#
+# Copyright (C) 2017-2021 The QC-Devs Community
+#
+# This file is part of Procrustes.
+#
+# Procrustes is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# Procrustes is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Common function used for testing."""
+
+
+import numpy as np
+from scipy.optimize import minimize
+
+
+def _vector_to_matrix(vec, nsize):
+    r"""Given a vector, change it to a matrix."""
+    mat = np.zeros((nsize, nsize))
+    mat[np.triu_indices(nsize)] = vec
+    mat = mat + mat.T - np.diag(np.diag(mat))
+    return mat
+
+
+def _objective_func(vec, array_a, array_b, nsize):
+    """Frobenius norm of AX-B for symmetric matrix X."""
+    mat = _vector_to_matrix(vec, nsize)
+    diff = array_a.dot(mat) - array_b
+    return np.trace(diff.T.dot(diff))
+
+
+def minimize_one_transformation(array_a, array_b, ncol):
+    """Find X matrix by minimizing Frobenius norm of AX-B."""
+    guess = np.random.random(int(ncol * (ncol + 1) / 2.0))
+    results = minimize(
+        _objective_func,
+        guess,
+        args=(array_a, array_b, ncol),
+        method="slsqp",
+        options={"eps": 1e-8, "ftol": 1e-11, "maxiter": 1000},
+    )
+    return _vector_to_matrix(results["x"], ncol), results["fun"]

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -28,7 +28,7 @@ from procrustes.generic import generic
 import pytest
 
 
-np.random.seed(2020)
+np.random.seed(2021)
 
 
 @pytest.mark.parametrize("m", np.random.randint(2, 100, 25))

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -28,7 +28,7 @@ from procrustes.generic import generic
 import pytest
 
 
-np.random.seed(2021)
+np.random.seed(2020)
 
 
 @pytest.mark.parametrize("m", np.random.randint(2, 100, 25))

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -70,7 +70,7 @@ def test_symmetric_scaled_shifted_transformed(m, n):
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
-@pytest.mark.parametrize("m, n", np.random.randint(5, 10, (25, 2)))
+@pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
 def test_symmetric_with_small_values(m, n):
     r"""Test symmetric by arrays with small values."""
     # define an arbitrary array_a, translation matrix & symmetric matrix
@@ -103,13 +103,19 @@ def test_not_full_rank_case():
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
-def test_having_zero_singular_case():
+@pytest.mark.parametrize("m", np.random.randint(50, 100, (25,)))
+def test_having_zero_eigenvalues_case(m):
     r"""Test symmetric that has zero singular values."""
-    # Define a matrix with not full singular values, e.g. 5 and 0 are singular values.
-    sing_mat = np.array([[5., 0.], [0., 0.], [0., 0.], [0., 0.]])
-    array_a = ortho_group.rvs(4).dot(sing_mat).dot(ortho_group.rvs(2))
-
-    sym_array = np.array([[0.38895636, 0.30523869], [0.30523869, 0.30856369]])
+    numb_nonzero_eigs = int(np.random.randint(1, m - 1))
+    # Define a matrix with not full eigenvalues values, e.g. 5 and 0 are eigenvalues values.
+    sing_mat = list(np.random.uniform(-10.0, 10.0, (numb_nonzero_eigs,)))
+    sing_mat += [0.] * (m - numb_nonzero_eigs)
+    sing_mat = np.diag(sing_mat)
+    array_a = ortho_group.rvs(m).dot(sing_mat).dot(ortho_group.rvs(m))
+    # Random symmetric matrix.
+    rand_array = np.random.uniform(-1., 1., (m, m))
+    sym_array = (rand_array + rand_array.T) / 2.0
+    # Defined array_b
     array_b = np.dot(array_a, sym_array)
     # compute procrustes transformation
     res = symmetric(array_a, array_b)

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -30,25 +30,23 @@ from scipy.optimize import minimize
 from scipy.stats import ortho_group
 
 
-def test_symmetric_transformed():
+@pytest.mark.parametrize("m, n, add_cols, add_rows", np.random.randint(50, 100, (5, 4)))
+def test_symmetric__with_unpadding(m, n, add_cols, add_rows):
     r"""Test symmetric without translation and scaling."""
-    # define arbitrary array and symmetric transformation
-    array_a = np.array([[1, 2, 4, 5],
-                        [5, 7, 3, 3],
-                        [1, 5, 1, 9],
-                        [1, 5, 2, 7],
-                        [5, 7, 9, 0]])
-    sym_array = np.dot(np.array([[1, 7, 4, 9]]).T, np.array([[1, 7, 4, 9]]))
+    # define arbitrary array and generate random symmetric transformation with rank 1.
+    array_a = np.random.uniform(-10.0, 10.0, (m, n))
+    rand_array = np.random.uniform(-10., 10., (n,))
+    sym_array = np.outer(rand_array.T, rand_array)
     # define array_b by transforming array_a and padding with zero
     array_b = np.dot(array_a, sym_array)
-    array_b = np.concatenate((array_b, np.zeros((5, 2))), axis=1)
-    array_b = np.concatenate((array_b, np.zeros((8, 6))), axis=0)
+    array_b = np.concatenate((array_b, np.zeros((m, add_cols))), axis=1)
+    array_b = np.concatenate((array_b, np.zeros((add_rows, n + add_cols))), axis=0)
     # compute procrustes transformation
     res = symmetric(array_a, array_b, unpad_col=True, unpad_row=True)
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["t"], res["t"].T, decimal=6)
-    assert_almost_equal(res["t"], sym_array, decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
+    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
 
 
 def test_symmetric_scaled_shifted_tranformed():

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -76,11 +76,11 @@ def test_symmetric_scaled_shifted_transformed(m, n):
 def test_symmetric_with_small_values(m, n):
     r"""Test symmetric by arrays with small values."""
     # define an arbitrary array_a, translation matrix & symmetric matrix
-    array_a = np.random.uniform(0.0, 1e-6, (m, n))
+    array_a = np.random.uniform(0.0, 1.0e-6, (m, n))
     # Define shift to the rows of the matrices. This repeats a random matrix of size n, m times.
-    shift = np.tile(np.random.uniform(-1.e-6, 1.e-6, (n,)), (m, 1))
+    shift = np.tile(np.random.uniform(-1.0e-6, 1.0e-6, (n,)), (m, 1))
     # Random symmetric matrix.
-    rand_array = np.random.uniform(-1., 1., (n, n))
+    rand_array = np.random.uniform(-1.0, 1.0, (n, n))
     sym_array = (rand_array + rand_array.T) / 2.0
     # define array_b by scaling, translating and transforming array_a
     array_b = 6.61e-4 * array_a + shift
@@ -95,62 +95,62 @@ def test_symmetric_with_small_values(m, n):
 
 def test_not_full_rank_case():
     r"""Test symmetric with not full rank case."""
-    # Define a random matrix and symmetric matrix
+    # define a random matrix and symmetric matrix
     array_a = np.array([[10, 83], [52, 58], [58, 44]])
     sym_array = np.array([[0.38895636, 0.30523869], [0.30523869, 0.30856369]])
     array_b = np.dot(array_a, sym_array)
-    # compute procrustes transformation
+    # compute procrustes transformation & check results
     res = symmetric(array_a, array_b)
-    # check transformation is symmetric & error is zero
     assert_equal(res.s, None)
     assert_almost_equal(res.t, res.t.T, decimal=6)
     assert_almost_equal(res.error, 0.0, decimal=6)
 
 
 @pytest.mark.parametrize("m", np.random.randint(50, 100, (25,)))
+# @pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
 def test_having_zero_eigenvalues_case(m):
     r"""Test symmetric that has zero singular values."""
+    # define a singular matrix (i.e. some eigenvalues are hard zeros)
     numb_nonzero_eigs = int(np.random.randint(1, m - 1))
-    # Define a matrix with not full eigenvalues values, e.g. 5 and 0 are eigenvalues values.
     sing_mat = list(np.random.uniform(-10.0, 10.0, (numb_nonzero_eigs,)))
     sing_mat += [0.] * (m - numb_nonzero_eigs)
     sing_mat = np.diag(sing_mat)
     array_a = ortho_group.rvs(m).dot(sing_mat).dot(ortho_group.rvs(m))
-    # Random symmetric matrix.
+    # generate random symmetric matrix & define matrix b
     rand_array = np.random.uniform(-1., 1., (m, m))
     sym_array = (rand_array + rand_array.T) / 2.0
-    # Defined array_b
     array_b = np.dot(array_a, sym_array)
-    # compute procrustes transformation
+    # compute procrustes transformation & check results
     res = symmetric(array_a, array_b)
-    # check transformation is symmetric & error is zero
     assert_equal(res.s, None)
     assert_almost_equal(res.t, res.t.T, decimal=6)
     assert_almost_equal(res.error, 0.0, decimal=6)
 
 
-@pytest.mark.parametrize("ncol", [2, 10, 15])
+@pytest.mark.parametrize("ncol", np.random.randint(2, 15, (3,)))
 def test_random_tall_rectangular_matrices(ncol):
     r"""Test Symmetric Procrustes with random tall matrices."""
+    # generate random floats in [0.0, 1.0) interval
     nrow = np.random.randint(ncol, ncol + 10)
     array_a, array_b = np.random.random((nrow, ncol)), np.random.random((nrow, ncol))
-
+    # minimize objective function to find transformation matrix
     desired, desired_func = minimize_one_transformation(array_a, array_b, ncol)
+    # compute transformation & check results
     res = symmetric(array_a, array_b, unpad_col=True, unpad_row=True)
+    assert_equal(res.s, None)
+    assert_almost_equal(np.abs(res.error - desired_func), 0.0, decimal=5)
+    assert_almost_equal(np.abs(res.t - desired), 0.0, decimal=3)
 
-    assert np.abs(res.error - desired_func) < 1e-5
-    assert np.all(np.abs(res.t - desired) < 1e-3)
 
-
-@pytest.mark.parametrize("nrow", [2, 10, 15])
+@pytest.mark.parametrize("nrow", np.random.randint(2, 15, (3,)))
 def test_fat_rectangular_matrices_with_square_padding(nrow):
     r"""Test Symmetric Procrustes with random wide matrices."""
-    # generate Random Rectangular Matrices
+    # generate random rectangular matrices
     ncol = np.random.randint(nrow + 1, nrow + 10)
     array_a, array_b = np.random.random((nrow, ncol)), np.random.random((nrow, ncol))
-
+    # minimize objective function to find transformation matrix
     _, desired_func = minimize_one_transformation(array_a, array_b, ncol)
     res = symmetric(array_a, array_b, pad=True)
-
-    # No uniqueness in solution, thus check that the optimal values are the same.
-    assert np.abs(res["error"] - desired_func) < 1e-5
+    # check results (solution is not uniqueness)
+    assert_almost_equal(np.abs(res.error - desired_func), 0.0, decimal=5)
+    assert_equal(res.s, None)

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -44,9 +44,9 @@ def test_symmetric_with_unpadding(m, n, add_cols, add_rows):
     # compute procrustes transformation
     res = symmetric(array_a, array_b, unpad_col=True, unpad_row=True)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["t"], res["t"].T, decimal=6)
-    assert_almost_equal(res["error"], 0.0, decimal=6)
-    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
+    assert_almost_equal(res.t, res.t.T, decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=6)
+    assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
@@ -65,9 +65,9 @@ def test_symmetric_scaled_shifted_transformed(m, n):
     # compute procrustes transformation
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["t"], res["t"].T, decimal=6)
-    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
-    assert_almost_equal(res["error"], 0.0, decimal=6)
+    assert_almost_equal(res.t, res.t.T, decimal=6)
+    assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
@@ -86,8 +86,8 @@ def test_symmetric_with_small_values(m, n):
     # compute procrustes transformation
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["t"], res["t"].T, decimal=6)
-    assert_almost_equal(res["error"], 0.0, decimal=5)
+    assert_almost_equal(res.t, res.t.T, decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=5)
 
 
 def test_not_full_rank_case():
@@ -99,8 +99,8 @@ def test_not_full_rank_case():
     # compute procrustes transformation
     res = symmetric(array_a, array_b)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["t"], res["t"].T, decimal=6)
-    assert_almost_equal(res["error"], 0.0, decimal=6)
+    assert_almost_equal(res.t, res.t.T, decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=6)
 
 
 @pytest.mark.parametrize("m", np.random.randint(50, 100, (25,)))
@@ -120,8 +120,8 @@ def test_having_zero_eigenvalues_case(m):
     # compute procrustes transformation
     res = symmetric(array_a, array_b)
     # check transformation is symmetric & error is zero
-    assert_almost_equal(res["t"], res["t"].T, decimal=6)
-    assert_almost_equal(res["error"], 0.0, decimal=6)
+    assert_almost_equal(res.t, res.t.T, decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=6)
 
 
 class TestAgainstNumerical:
@@ -162,8 +162,8 @@ class TestAgainstNumerical:
         desired, desired_func = self._optimize(array_a, array_b, ncol)
         res = symmetric(array_a, array_b, unpad_col=True, unpad_row=True)
 
-        assert np.abs(res["error"] - desired_func) < 1e-5
-        assert np.all(np.abs(res["t"] - desired) < 1e-3)
+        assert np.abs(res.error - desired_func) < 1e-5
+        assert np.all(np.abs(res.t - desired) < 1e-3)
 
     @pytest.mark.parametrize("nrow", [2, 10, 15])
     def test_fat_rectangular_matrices_with_square_padding(self, nrow):

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -23,7 +23,7 @@
 """Testings for symmetric Procrustes module."""
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_equal
 from procrustes import symmetric
 import pytest
 from scipy.optimize import minimize
@@ -46,6 +46,7 @@ def test_symmetric_with_unpadding(m, n, add_cols, add_rows):
     # check transformation is symmetric & error is zero
     assert_almost_equal(res.t, res.t.T, decimal=6)
     assert_almost_equal(res.error, 0.0, decimal=6)
+    assert_equal(res.s, None)
     assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
 
 
@@ -67,6 +68,7 @@ def test_symmetric_scaled_shifted_transformed(m, n):
     # check transformation is symmetric & error is zero
     assert_almost_equal(res.t, res.t.T, decimal=6)
     assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
+    assert_equal(res.s, None)
     assert_almost_equal(res.error, 0.0, decimal=6)
 
 
@@ -86,6 +88,7 @@ def test_symmetric_with_small_values(m, n):
     # compute procrustes transformation
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
+    assert_equal(res.s, None)
     assert_almost_equal(res.t, res.t.T, decimal=6)
     assert_almost_equal(res.error, 0.0, decimal=5)
 
@@ -99,6 +102,7 @@ def test_not_full_rank_case():
     # compute procrustes transformation
     res = symmetric(array_a, array_b)
     # check transformation is symmetric & error is zero
+    assert_equal(res.s, None)
     assert_almost_equal(res.t, res.t.T, decimal=6)
     assert_almost_equal(res.error, 0.0, decimal=6)
 
@@ -120,6 +124,7 @@ def test_having_zero_eigenvalues_case(m):
     # compute procrustes transformation
     res = symmetric(array_a, array_b)
     # check transformation is symmetric & error is zero
+    assert_equal(res.s, None)
     assert_almost_equal(res.t, res.t.T, decimal=6)
     assert_almost_equal(res.error, 0.0, decimal=6)
 

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -54,11 +54,11 @@ def test_symmetric_scaled_shifted_transformed(m, n):
     r"""Test symmetric with translation and scaling."""
     # define an arbitrary array_a, translation matrix & symmetric matrix
     array_a = np.random.uniform(-10.0, 10.0, (m, n))
-    shift = np.random.uniform(-10.0, 10.0, (m, n))
+    # Define shift to the rows of the matrices. This repeats a random matrix of size n, m times.
+    shift = np.tile(np.random.uniform(-10.0, 10.0, (n,)), (m, 1))
     # Generate random array with rank with which ever is the smallest.
     rand_array = np.random.uniform(-10., 10., (m, n))
     sym_array = np.dot(rand_array.T, rand_array)
-    print(sym_array.shape, array_a.shape, m, n)
     # define array_b by scaling, translating and transforming array_a
     array_b = 614.5 * array_a + shift
     array_b = np.dot(array_b, sym_array)
@@ -66,36 +66,21 @@ def test_symmetric_scaled_shifted_transformed(m, n):
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["t"], res["t"].T, decimal=6)
-    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=4)
-    assert_almost_equal(res["error"], 0.0, decimal=5)
-
-
-def test_symmetric_scaled_shifted_tranformed_4by3():
-    r"""Test symmetric by 4by3 array with translation and scaling."""
-    # define an arbitrary array_a, translation matrix & symmetric matrix
-    array_a = np.array([[245.0, 122.4, 538.5], [122.5, 252.2, 352.2],
-                        [152.5, 515.2, 126.5], [357.5, 312.5, 225.5]])
-    shift = np.array([[19.3, 14.2, 13.1], [19.3, 14.2, 13.1],
-                      [19.3, 14.2, 13.1], [19.3, 14.2, 13.1]])
-    sym_array = np.dot(np.array([[111.4, 144.9, 249.6]]).T, np.array([[111.4, 144.9, 249.6]]))
-    # define array_b by scaling, translating and transforming array_a
-    array_b = 312.5 * array_a + shift
-    array_b = np.dot(array_b, sym_array)
-    # compute procrustes transformation
-    res = symmetric(array_a, array_b, translate=True, scale=True)
-    # check transformation is symmetric & error is zero
-    assert_almost_equal(res["t"], res["t"].T, decimal=6)
+    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
-def test_symmetric():
+@pytest.mark.parametrize("m, n", np.random.randint(5, 10, (25, 2)))
+def test_symmetric_with_small_values(m, n):
     r"""Test symmetric by arrays with small values."""
+    if n <= m:
+        n = m
     # define an arbitrary array_a, translation matrix & symmetric matrix
-    array_a = np.array([[5.52e-5, 2.15e-5, 8.12e-5], [2.14e-5, 2.22e-5, 3.14e-5],
-                        [1.11e-5, 5.94e-5, 6.58e-5], [7.15e-5, 3.62e-5, 2.24e-5]])
-    shift = np.array([[9.42e-6, 4.32e-6, 3.22e-5], [9.42e-6, 4.32e-6, 3.22e-5],
-                      [9.42e-6, 4.32e-6, 3.22e-5], [9.42e-6, 4.32e-6, 3.22e-5]])
-    sym_array = np.dot(np.array([[5.2, 6.7, 3.5]]).T, np.array([[5.2, 6.7, 3.5]]))
+    array_a = np.random.uniform(0.0, 1., (m, n))
+    shift = np.random.uniform(0.0, 1., (m, n))
+    # Random positive Semidefinite symmetric matrix.
+    rand_array = np.random.uniform(-1., 1., (n, n))
+    sym_array = (rand_array + rand_array.T) / 2.0
     # define array_b by scaling, translating and transforming array_a
     array_b = 6.61e-4 * array_a + shift
     array_b = np.dot(array_b, sym_array)
@@ -103,7 +88,7 @@ def test_symmetric():
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["t"], res["t"].T, decimal=6)
-    assert_almost_equal(res["error"], 0.0, decimal=6)
+    assert_almost_equal(res["error"], 0.0, decimal=5)
 
 
 def test_not_full_rank_case():

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -31,7 +31,7 @@ from scipy.stats import ortho_group
 
 
 @pytest.mark.parametrize("m, n, add_cols, add_rows", np.random.randint(50, 100, (5, 4)))
-def test_symmetric__with_unpadding(m, n, add_cols, add_rows):
+def test_symmetric_with_unpadding(m, n, add_cols, add_rows):
     r"""Test symmetric without translation and scaling."""
     # define arbitrary array and generate random symmetric transformation with rank 1.
     array_a = np.random.uniform(-10.0, 10.0, (m, n))
@@ -49,12 +49,16 @@ def test_symmetric__with_unpadding(m, n, add_cols, add_rows):
     assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
 
 
-def test_symmetric_scaled_shifted_tranformed():
+@pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
+def test_symmetric_scaled_shifted_transformed(m, n):
     r"""Test symmetric with translation and scaling."""
     # define an arbitrary array_a, translation matrix & symmetric matrix
-    array_a = np.array([[5, 2, 8], [2, 2, 3], [1, 5, 6], [7, 3, 2]], dtype=float)
-    shift = np.array([[9., 4., 3.], [9., 4., 3.], [9., 4., 3.], [9., 4., 3.]])
-    sym_array = np.dot(np.array([[1, 4, 9]]).T, np.array([[1, 4, 9]]))
+    array_a = np.random.uniform(-10.0, 10.0, (m, n))
+    shift = np.random.uniform(-10.0, 10.0, (m, n))
+    # Generate random array with rank with which ever is the smallest.
+    rand_array = np.random.uniform(-10., 10., (m, n))
+    sym_array = np.dot(rand_array.T, rand_array)
+    print(sym_array.shape, array_a.shape, m, n)
     # define array_b by scaling, translating and transforming array_a
     array_b = 614.5 * array_a + shift
     array_b = np.dot(array_b, sym_array)
@@ -62,7 +66,8 @@ def test_symmetric_scaled_shifted_tranformed():
     res = symmetric(array_a, array_b, translate=True, scale=True)
     # check transformation is symmetric & error is zero
     assert_almost_equal(res["t"], res["t"].T, decimal=6)
-    assert_almost_equal(res["error"], 0.0, decimal=6)
+    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=4)
+    assert_almost_equal(res["error"], 0.0, decimal=5)
 
 
 def test_symmetric_scaled_shifted_tranformed_4by3():

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -124,18 +124,6 @@ def test_having_zero_eigenvalues_case(m):
     assert_almost_equal(res["error"], 0.0, decimal=6)
 
 
-# def test_fat_rectangular_matrices_raises_error_no_padding():
-#     r"""Test Symmetric Procrustes raises error when improper padding."""
-#     # Generate Random Rectangular Matrices
-#     nrow = 3
-#     ncol = np.random.randint(nrow + 1, nrow + 4)
-#     array_a, array_b = np.random.random((nrow, ncol)), np.random.random((nrow, ncol))
-#     np.testing.assert_raises(ValueError, symmetric, array_a, array_b)
-#
-#     array_a = np.random.random((nrow, nrow))
-#     np.testing.assert_raises(ValueError, symmetric, array_a, array_b)
-
-
 class TestAgainstNumerical:
     r"""
     Testing Procrustes over symmetric matrices against numerical optimization methods.

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -73,12 +73,11 @@ def test_symmetric_scaled_shifted_transformed(m, n):
 @pytest.mark.parametrize("m, n", np.random.randint(5, 10, (25, 2)))
 def test_symmetric_with_small_values(m, n):
     r"""Test symmetric by arrays with small values."""
-    if n <= m:
-        n = m
     # define an arbitrary array_a, translation matrix & symmetric matrix
-    array_a = np.random.uniform(0.0, 1., (m, n))
-    shift = np.random.uniform(0.0, 1., (m, n))
-    # Random positive Semidefinite symmetric matrix.
+    array_a = np.random.uniform(0.0, 1e-6, (m, n))
+    # Define shift to the rows of the matrices. This repeats a random matrix of size n, m times.
+    shift = np.tile(np.random.uniform(-1.e-6, 1.e-6, (n,)), (m, 1))
+    # Random symmetric matrix.
     rand_array = np.random.uniform(-1., 1., (n, n))
     sym_array = (rand_array + rand_array.T) / 2.0
     # define array_b by scaling, translating and transforming array_a


### PR DESCRIPTION
This pull request changes how testing is done in symmetric.py to be more general and randomized.

The function signature of Procrustes problem with symmetric matrices is changed wrt to "remove_zero_cols" and "remove_zero_rows" to be more consistent with the other functions with "unpad_col", and "unpad_row" (90ca479).  
Some tests were removed, since they were duplicates with very small matrix size being tested (223c77a).
There were code that was commented out (57ffb8c) and a test (9551c87) corresponding to it that was commented out. I decided to remove them.