### PR TITLE
Refactor test orthogonal

### DIFF
--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -47,8 +47,13 @@ def orthogonal(
     r"""Perform orthogonal Procrustes.
 
     Given a matrix :math:`\mathbf{A}_{m \times n}` and a reference matrix :math:`\mathbf{B}_{m
+<<<<<<< HEAD
     \times n}`, find the orthogonal (i.e., unitary) transformation matrix :math:`\mathbf{Q}_{n
     \times n}` that makes :math:`\mathbf{AQ}` as close as possible to :math:`\mathbf{B}`.
+=======
+    \times n}`, find the orthogonal transformation matrix :math:`\mathbf{U}_{n
+    \times n}`that makes :math:`\mathbf{A}` as close as possible to :math:`\mathbf{B}`.
+>>>>>>> Removed unitary word in the docs
     In other words,
 
     .. math::

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -47,13 +47,8 @@ def orthogonal(
     r"""Perform orthogonal Procrustes.
 
     Given a matrix :math:`\mathbf{A}_{m \times n}` and a reference matrix :math:`\mathbf{B}_{m
-<<<<<<< HEAD
     \times n}`, find the orthogonal (i.e., unitary) transformation matrix :math:`\mathbf{Q}_{n
     \times n}` that makes :math:`\mathbf{AQ}` as close as possible to :math:`\mathbf{B}`.
-=======
-    \times n}`, find the orthogonal transformation matrix :math:`\mathbf{U}_{n
-    \times n}`that makes :math:`\mathbf{A}` as close as possible to :math:`\mathbf{B}`.
->>>>>>> Removed unitary word in the docs
     In other words,
 
     .. math::

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -47,7 +47,7 @@ def orthogonal(
     r"""Perform orthogonal Procrustes.
 
     Given a matrix :math:`\mathbf{A}_{m \times n}` and a reference matrix :math:`\mathbf{B}_{m
-    \times n}`, find the orthogonal (i.e., unitary) transformation matrix :math:`\mathbf{Q}_{n
+    \times n}`, find the orthogonal transformation matrix :math:`\mathbf{Q}_{n
     \times n}` that makes :math:`\mathbf{AQ}` as close as possible to :math:`\mathbf{B}`.
     In other words,
 
@@ -167,7 +167,7 @@ def orthogonal_2sided(
     r"""Perform two-sided orthogonal Procrustes with one- or two-transformations.
 
     **Two Transformations:** Given a matrix :math:`\mathbf{A}_{m \times n}` and a reference matrix
-    :math:`\mathbf{B}_{m \times n}`, find two :math:`n \times n` orthogonal (i.e., unitary)
+    :math:`\mathbf{B}_{m \times n}`, find two :math:`n \times n` orthogonal
     transformation matrices :math:`\mathbf{Q}_1^\dagger` and :math:`\mathbf{Q}_2` that makes
     :math:`\mathbf{Q}_1^\dagger\mathbf{A}\mathbf{Q}_2` as close as possible to :math:`\mathbf{B}`.
     In other words,
@@ -179,7 +179,7 @@ def orthogonal_2sided(
             \|\mathbf{Q}_1^\dagger \mathbf{A} \mathbf{Q}_2 - \mathbf{B}\|_{F}^2
 
     **Single Transformations:** Given a **symmetric** matrix :math:`\mathbf{A}_{n \times n}` and
-    a reference :math:`\mathbf{B}_{n \times n}`, find one orthogonal (i.e., unitary) transformation
+    a reference :math:`\mathbf{B}_{n \times n}`, find one orthogonal transformation
     matrix :math:`\mathbf{Q}_{n \times n}` that makes :math:`\mathbf{A}` as close as possible to
     :math:`\mathbf{B}`. In other words,
 

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -71,29 +71,23 @@ def test_procrustes_rotation_square(n):
 def test_procrustes_reflection_square(n):
     r"""Test orthogonal Procrustes with reflected squared array."""
     # square array
-    array_a = np.array([[2.0, 0.1], [0.5, 3.0]])
-    # reflection through origin
+    array_a = np.random.uniform(-10.0, 10.0, (n, n))
+    # reflection through diagonal plane
     array_b = -array_a
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_almost_equal(res["t"], np.array([[-1, 0], [0, -1]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
-    # reflection in the x-axis
-    array_b = np.array([[2.0, -0.1], [0.5, -3.0]])
+    assert_almost_equal(res["t"], -np.eye(n), decimal=6)
+    assert_almost_equal(res["error"], 0., decimal=6)
+    # General reflection through random hyperplane, see Wikipedia "Reflection (mathematics)"
+    a = np.random.uniform(-10.0, 10.0, (n))
+    a /= np.linalg.norm(a)
+    rotation = np.eye(n) - 2.0 * np.outer(a, a) / np.linalg.norm(a)**2.0
+    array_b = array_a.dot(rotation)
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["t"], np.array([[1, 0], [0, -1]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
-    # reflection in the y-axis
-    array_b = np.array([[-2.0, 0.1], [-0.5, 3.0]])
-    res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["t"], np.array([[-1, 0], [0, 1]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
-    # reflection in the line y=x
-    array_b = np.array([[0.1, 2.0], [3.0, 0.5]])
-    res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["t"], np.array([[0, 1], [1, 0]]), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
+    assert_almost_equal(res["t"], rotation, decimal=6)
+    assert_almost_equal(res["error"], 0., decimal=6)
+    assert_almost_equal(array_a.dot(rotation), array_b, decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -254,7 +254,7 @@ def test_two_sided_orthogonal_single_transformation_identical(n):
     # define an arbitrary symmetric array
     array_a = np.random.uniform(-10.0, 10.0, (n, n))
     array_a = np.dot(array_a, array_a.T)
-    array_b = np.copy(array_a)  
+    array_b = np.copy(array_a)
 
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
     # check transformation array and error
@@ -264,28 +264,27 @@ def test_two_sided_orthogonal_single_transformation_identical(n):
     assert_almost_equal(result.error, 0, decimal=8)
 
 
-def test_two_sided_orthogonal_single_transformation_rot_reflect_padded():
-    r"""Test 2sided orthogonal by array with translation, rotation, reflection and zero padding."""
+@pytest.mark.parametrize("n, ncol, nrow", np.random.randint(50, 100, (25, 3)))
+def test_two_sided_orthogonal_single_transformation_rot_reflect_unpadded(n, ncol, nrow):
+    r"""Test 2sided orthogonal by array with translation, rotation, reflection and unpadding."""
     # define an arbitrary symmetric array
-    array = np.array([[5, 2, 1], [4, 6, 1], [1, 6, 3]])
+    array = np.random.uniform(-10.0, 10.0, (n, n))
     array_a = np.dot(array, array.T)
     # define transformation arrays as a combination of rotation and reflection
-    theta = 16. * np.pi / 5.
-    rot = np.array([[np.cos(theta), -np.sin(theta), 0.],
-                    [np.sin(theta), np.cos(theta), 0.], [0., 0., 1.]])
-    ref = 1. / 3 * np.array([[1, -2, -2], [-2, 1, -2], [-2, -2, 1]])
+    rot = ortho_group.rvs(n)
+    ref = generate_random_reflection_matrix(n)
     trans = np.dot(rot, ref)
     # define array_b by transforming array_a and padding with zero
     array_b = np.dot(np.dot(trans.T, array_a), trans)
-    array_b = np.concatenate((array_b, np.zeros((3, 5))), axis=1)
-    array_b = np.concatenate((array_b, np.zeros((5, 8))), axis=0)
+    array_b = np.concatenate((array_b, np.zeros((n, ncol))), axis=1)
+    array_b = np.concatenate((array_b, np.zeros((nrow, n + ncol))), axis=0)
 
     # check transformation array and error.
     result = orthogonal_2sided(array_a, array_b, single_transform=True, unpad_col=True,
                                unpad_row=True)
-    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
-    assert_almost_equal(result["error"], 0, decimal=8)
+    assert_almost_equal(np.dot(result.t, result.t.T), np.eye(n), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result.t)), 1.0, decimal=8)
+    assert_almost_equal(result.error, 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_3by3():

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -248,19 +248,20 @@ def test_two_sided_orthogonal_with_translation_and_scaling(m, n):
     assert_almost_equal(result.error, 0, decimal=4)
 
 
-def test_two_sided_orthogonal_single_transformation_identical():
+@pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
+def test_two_sided_orthogonal_single_transformation_identical(n):
     r"""Test 2sided orthogonal with identical arrays."""
     # define an arbitrary symmetric array
-    array_a = np.array([[2, 5, 4, 1], [5, 3, 1, 2], [8, 9, 1, 0], [1, 5, 6, 7]])
+    array_a = np.random.uniform(-10.0, 10.0, (n, n))
     array_a = np.dot(array_a, array_a.T)
-    array_b = np.copy(array_a)
+    array_b = np.copy(array_a)  
 
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(4), decimal=8)
-    assert_almost_equal(abs(result["t"]), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
-    assert_almost_equal(result["error"], 0, decimal=8)
+    assert_almost_equal(np.dot(result.t, result.t.T), np.eye(n), decimal=8)
+    assert_almost_equal(abs(result.t), np.eye(n), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result.t)), 1.0, decimal=8)
+    assert_almost_equal(result.error, 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_rot_reflect_padded():

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -26,6 +26,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 from procrustes.orthogonal import orthogonal, orthogonal_2sided
 from procrustes.utils import compute_error
+import pytest
 
 
 def make_rotation_array(theta):
@@ -36,33 +37,17 @@ def make_rotation_array(theta):
     return arr
 
 
-def test_procrustes_orthogonal_identical():
+@pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
+def test_procrustes_orthogonal_identical(m, n):
     r"""Test orthogonal Procrustes with identity matrix."""
     # case of identical square arrays
-    array_a = np.arange(9).reshape(3, 3)
-    array_b = np.copy(array_a)
-    res = orthogonal(array_a, array_b)
-    # check transformation array is identity
-    assert_almost_equal(res["new_a"], array_a, decimal=6)
-    assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
-    # case of identical rectangular arrays (2 by 4)
-    array_a = np.array([[1, 5, 6, 7], [1, 2, 9, 4]])
+    array_a = np.random.uniform(-10.0, 10.0, (m, n))
     array_b = np.copy(array_a)
     res = orthogonal(array_a, array_b)
     assert_almost_equal(res["new_a"], array_a, decimal=6)
     assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_equal(res["t"].shape, (4, 4))
-    # assert_almost_equal(array_u, np.eye(4), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
-    # case of identical rectangular arrays (5 by 3)
-    array_a = np.arange(15).reshape(5, 3)
-    array_b = np.copy(array_a)
-    res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["new_a"], array_a, decimal=6)
-    assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_equal(res["t"].shape, (3, 3))
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
+    assert_almost_equal(res["error"], 0., decimal=6)
+    assert_almost_equal(array_a.dot(res["t"]), array_b)
 
 
 def test_procrustes_rotation_square():

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -166,7 +166,7 @@ def test_two_sided_orthogonal_identical(n):
 
 
 def test_orthogonal_raises_error():
-    r"""Test that orthogonal with incorrect shape raises error"""
+    r"""Test that orthogonal with incorrect shape raises error."""
     array_a = np.random.uniform(-10.0, 10.0, (10, 20))
     array_b = array_a.copy()
     array_b = np.concatenate((array_b, np.zeros((10, 5))), axis=1)

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -287,25 +287,24 @@ def test_two_sided_orthogonal_single_transformation_rot_reflect_unpadded(n, ncol
     assert_almost_equal(result.error, 0, decimal=8)
 
 
-def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
+@pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
+def test_two_sided_orthogonal_single_transformation_with_scaling(n):
     r"""Test 2sided orthogonal by 3by3 array with scaling, rotation and reflection."""
     # define an arbitrary symmetric array
-    array_a = np.array([[124.72, 147.93], [120.5, 59.41]])
+    array_a = np.random.uniform(-10.0, 10.0, (n, n))
     array_a = np.dot(array_a, array_a.T)
     # define transformation composed of rotation and reflection
-    theta = 5.5 * np.pi / 6.5
-    rot = np.array([[np.cos(theta), -np.sin(theta)],
-                    [np.sin(theta), np.cos(theta)]])
-    ref = np.array([[1., 0.], [0., -1.]])
+    rot = ortho_group.rvs(n)
+    ref = generate_random_reflection_matrix(n)
     trans = np.dot(ref, rot)
     # define array_b by transforming scaled array_a
     array_b = np.dot(np.dot(trans.T, 88.89 * array_a), trans)
 
     # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, single_transform=True, translate=False, scale=True)
-    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(2), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
-    assert_almost_equal(result["error"], 0, decimal=8)
+    assert_almost_equal(np.dot(result.t, result.t.T), np.eye(n), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result.t)), 1.0, decimal=8)
+    assert_almost_equal(result.error, 0, decimal=8)
 
 
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -44,6 +44,7 @@ def test_procrustes_orthogonal_identical(m, n):
     array_a = np.random.uniform(-10.0, 10.0, (m, n))
     array_b = np.copy(array_a)
     res = orthogonal(array_a, array_b)
+    assert_equal(res.s, None)
     assert_almost_equal(res.new_a, array_a, decimal=6)
     assert_almost_equal(res.new_b, array_b, decimal=6)
     assert_almost_equal(res.t.dot(res.t.T), np.eye(n), decimal=6)
@@ -63,6 +64,7 @@ def test_procrustes_rotation_square(n):
     assert_almost_equal(res.error, 0., decimal=6)
     assert_almost_equal(res.t.dot(res.t.T), np.eye(n), decimal=6)
     assert_almost_equal(res.t, ortho_arr)
+    assert_equal(res.s, None)
 
 
 @pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
@@ -86,6 +88,7 @@ def test_procrustes_reflection_square(n):
     assert_almost_equal(res.t, rotation, decimal=6)
     assert_almost_equal(res.error, 0., decimal=6)
     assert_almost_equal(array_a.dot(rotation), array_b, decimal=6)
+    assert_equal(res.s, None)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
@@ -101,6 +104,7 @@ def test_procrustes_with_translation(m, n):
     assert_almost_equal(res.t.T.dot(res.t), np.eye(n), decimal=6)
     assert_almost_equal(res.error, 0., decimal=6)
     assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
+    assert_equal(res.s, None)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
@@ -122,6 +126,7 @@ def test_orthogonal_with_translate_and_scale(m, n):
     assert_almost_equal(res.t.T.dot(res.t), np.eye(n), decimal=6)
     assert_almost_equal(res.error, 0., decimal=6)
     assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
+    assert_equal(res.s, None)
 
 
 @pytest.mark.parametrize("m, n, ncols, nrows", np.random.randint(50, 100, (25, 4)))
@@ -142,6 +147,7 @@ def test_orthogonal_translate_scale_with_unpadding(m, n, ncols, nrows):
     assert_almost_equal(res.error, 0., decimal=6)
     assert_almost_equal(res.t.T.dot(res.t), np.eye(n), decimal=6)
     assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
+    assert_equal(res.s, None)
 
 
 @pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -140,28 +140,29 @@ def test_orthogonal_translate_scale_with_unpadding(m, n, ncols, nrows):
     array_b = np.concatenate((array_b, np.zeros((nrows, n + ncols))), axis=0)
     # compute procrustes transformation
     res = orthogonal(array_a, array_b, translate=False, scale=False, unpad_col=True, unpad_row=True)
-    assert_almost_equal(res["new_b"], np.dot(array_a, ortho))
+    assert_almost_equal(res["new_b"], np.dot(array_a, ortho), decimal=6)
     assert_almost_equal(res["error"], 0., decimal=6)
     assert_almost_equal(res["t"].T.dot(res["t"]), np.eye(n), decimal=6)
     assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
 
 
-def test_two_sided_orthogonal_identical():
+@pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
+def test_two_sided_orthogonal_identical(n):
     r"""Test 2-sided orthogonal with identical matrix."""
     # case of identical square arrays
-    array_a = np.arange(16).reshape(4, 4)
+    array_a = np.random.uniform(-10.0, 10.0, (n, n))
     array_b = np.copy(array_a)
     result = orthogonal_2sided(array_a, array_b, single_transform=False)
     # check transformation array is identity
     assert_almost_equal(np.linalg.det(result["s"]), 1.0, decimal=6)
     assert_almost_equal(np.linalg.det(result["t"]), 1.0, decimal=6)
-    assert_almost_equal(result["s"], np.eye(4), decimal=6)
-    assert_almost_equal(result["t"], np.eye(4), decimal=6)
+    assert_almost_equal(result["s"], np.eye(n), decimal=6)
+    assert_almost_equal(result["t"], np.eye(n), decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
 
 
 def test_two_sided_orthogonal_raises_error_non_symmetric_matrices():
-    r"""Test that 2-sided orthogonal procrustes non-symmetric matrices return an error."""
+    r"""Test that 2-sided orthogonal procrustes non-symmetric matrices raises an error."""
     # Test simple example with one matrix that is not square
     array_a = np.array([[1., 2., 3.], [1., 2., 3.]])
     array_b = np.array([[1., 2.], [2., 1.]])

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -289,7 +289,7 @@ def test_two_sided_orthogonal_single_transformation_rot_reflect_unpadded(n, ncol
 
 @pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
 def test_two_sided_orthogonal_single_transformation_with_scaling(n):
-    r"""Test 2sided orthogonal by 3by3 array with scaling, rotation and reflection."""
+    r"""Test 2sided orthogonal by array with scaling, rotation and reflection."""
     # define an arbitrary symmetric array
     array_a = np.random.uniform(-10.0, 10.0, (n, n))
     array_a = np.dot(array_a, array_a.T)
@@ -299,7 +299,6 @@ def test_two_sided_orthogonal_single_transformation_with_scaling(n):
     trans = np.dot(ref, rot)
     # define array_b by transforming scaled array_a
     array_b = np.dot(np.dot(trans.T, 88.89 * array_a), trans)
-
     # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, single_transform=True, translate=False, scale=True)
     assert_almost_equal(np.dot(result.t, result.t.T), np.eye(n), decimal=8)
@@ -307,18 +306,18 @@ def test_two_sided_orthogonal_single_transformation_with_scaling(n):
     assert_almost_equal(result.error, 0, decimal=8)
 
 
-def test_two_sided_orthogonal_single_transformation_random_orthogonal():
+@pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
+def test_two_sided_orthogonal_single_transformation_random_orthogonal(n):
     r"""Test 2sided orthogonal by 3by3 array."""
-    # define random array
-    array_a = np.array([[0, 5, 8, 6], [5, 0, 5, 1],
-                        [8, 5, 0, 2], [6, 1, 2, 0]])
-    ortho = np.array([[0, 0, 1, 0],
-                      [0, 0, 0, 1],
-                      [1, 0, 0, 0],
-                      [0, 1, 0, 0]])
+    # define random symmetric array
+    array_a = np.random.uniform(-10.0, 10.0, (n, n))
+    array_a = (array_a + array_a.T) / 2.0
+    # Obtain random orthogonal matrix.
+    ortho = ortho_group.rvs(n)
     array_b = np.dot(np.dot(ortho.T, array_a), ortho)
     # check transformation array and error
     result = orthogonal_2sided(array_a, array_b, single_transform=True)
-    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(4), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
-    assert_almost_equal(result["error"], 0, decimal=8)
+
+    assert_almost_equal(np.dot(result.t, result.t.T), np.eye(n), decimal=8)
+    assert_almost_equal(abs(np.linalg.det(result.t)), 1.0, decimal=8)
+    assert_almost_equal(result.error, 0, decimal=8)

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -67,7 +67,8 @@ def test_procrustes_rotation_square(n):
     assert_almost_equal(res["t"], ortho_arr)
 
 
-def test_procrustes_reflection_square():
+@pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
+def test_procrustes_reflection_square(n):
     r"""Test orthogonal Procrustes with reflected squared array."""
     # square array
     array_a = np.array([[2.0, 0.1], [0.5, 3.0]])
@@ -95,37 +96,19 @@ def test_procrustes_reflection_square():
     assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
 
 
-def test_procrustes_shifted():
-    r"""Test orthogonal Procrustes with shifted array."""
-    # square array
-    array_a = np.array([[3.5, 0.1, 7.0], [0.5, 2.0, 1.0], [8.1, 0.3, 0.7]])
-    # expected_a = array_a - np.mean(array_a, axis=0)
-    # constant shift
-    array_b = array_a + 4.1
+@pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
+def test_procrustes_with_translation(m, n):
+    r"""Test orthogonal Procrustes with translation."""
+    array_a = np.random.uniform(-10.0, 10.0, (m, n))
+    array_b = array_a + np.random.uniform(-10.0, 10.0, (n,))
     res = orthogonal(array_a, array_b, translate=True)
-    # assert_almost_equal(new_b, array_b, decimal=6)
-    assert_almost_equal(res["t"], np.eye(3), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
-    # different shift along each axis
-    array_b = array_a + np.array([0, 3.2, 5.0])
-    res = orthogonal(array_a, array_b, translate=True)
-    # assert_almost_equal(new_b, array_b, decimal=6)
-    assert_almost_equal(res["t"], np.eye(3), decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
-    # rectangular (2 by 3)
-    array_a = np.array([[1, 2, 3], [7, 9, 5]])
-    # expected_a = array_a - np.array([4., 5.5, 4.])
-    # constant shift
-    array_b = array_a + 0.71
-    res = orthogonal(array_a, array_b, translate=True)
-    # assert_almost_equal(new_b, array_b, decimal=6)
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
-    # different shift along each axis
-    array_b = array_a + np.array([0.3, 7.1, 4.2])
-    res = orthogonal(array_a, array_b, translate=True)
-    # assert_almost_equal(new_b, array_b, decimal=6)
-    assert_equal(res["t"].shape, (3, 3))
-    assert_almost_equal(compute_error(res["new_a"], res["new_b"], res["t"]), 0., decimal=6)
+    # Test that the new A and B are translation of the originals.
+    assert_almost_equal(res["new_a"], array_a - np.mean(array_a, axis=0), decimal=6)
+    assert_almost_equal(res["new_b"], array_a - np.mean(array_a, axis=0), decimal=6)
+    # Test that optimal result is orthogonal, and error is zero
+    assert_almost_equal(res["t"].T.dot(res["t"]), np.eye(n), decimal=6)
+    assert_almost_equal(res["error"], 0., decimal=6)
+    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
 
 
 def test_procrustes_rotation_translation():

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -248,26 +248,6 @@ def test_two_sided_orthogonal_with_translation_and_scaling(m, n):
     assert_almost_equal(result.error, 0, decimal=4)
 
 
-def test_two_sided_orthogonal_translate_scale_rotate_reflect_3by3():
-    r"""Test 2sided orthogonal by a another 3by3 array with translation, rotation and reflection."""
-    # define an arbitrary array
-    array_a = np.array([[141.58, 315.25, 524.14], [253.25, 255.52, 357.51], [358.2, 131.6, 135.59]])
-    # define rotation and reflection arrays
-    rot = make_rotation_array(17.54 * np.pi / 6.89)
-    ref = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, -1]])
-    # define array_b by transforming scaled-and-translated array_a
-    shift = np.array([[146.56, 441.67, 343.56], [146.56, 441.67, 343.56], [146.56, 441.67, 343.56]])
-    array_b = np.dot(np.dot(ref, 79.89 * array_a + shift), rot)
-    # compute procrustes transformation
-    result = orthogonal_2sided(array_a, array_b, single_transform=False, translate=True, scale=True)
-    # check transformation array and error
-    assert_almost_equal(np.dot(result["s"], result["s"].T), np.eye(3), decimal=6)
-    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["s"])), 1.0, decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=6)
-    assert_almost_equal(result["error"], 0, decimal=6)
-
-
 def test_two_sided_orthogonal_single_transformation_identical():
     r"""Test 2sided orthogonal with identical arrays."""
     # define an arbitrary symmetric array

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -287,27 +287,6 @@ def test_two_sided_orthogonal_single_transformation_rot_reflect_unpadded(n, ncol
     assert_almost_equal(result.error, 0, decimal=8)
 
 
-def test_two_sided_orthogonal_single_transformation_scale_3by3():
-    r"""Test 2sided orthogonal by 3by3 array with translation and scaling."""
-    # define an arbitrary symmetric array
-    array_a = np.array([[12.43, 16.15, 17.61], [11.4, 21.5, 16.7], [16.4, 19.4, 14.9]])
-    array_a = np.dot(array_a, array_a.T)
-    # define transformation composed of rotation and reflection
-    theta = np.pi / 2
-    rot = np.array([[np.cos(theta), -np.sin(theta), 0.],
-                    [np.sin(theta), np.cos(theta), 0.], [0., 0., 1.]])
-    ref = np.array([[1, -2, -2], [-2, 1, -2], [-2, -2, 1]])
-    trans = np.dot(ref, rot) / 3
-    # define array_b by transforming scaled-and-translated array_a
-    array_b = np.dot(np.dot(trans.T, 6.9 * array_a), trans)
-
-    # check transformation array and error
-    result = orthogonal_2sided(array_a, array_b, single_transform=True, translate=False, scale=True)
-    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
-    assert_almost_equal(result["error"], 0, decimal=8)
-
-
 def test_two_sided_orthogonal_single_transformation_scale_rot_ref_2by2():
     r"""Test 2sided orthogonal by 3by3 array with scaling, rotation and reflection."""
     # define an arbitrary symmetric array

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -25,9 +25,7 @@ r"""Testings for orthogonal Procrustes module."""
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 from procrustes.orthogonal import orthogonal, orthogonal_2sided
-from procrustes.utils import compute_error
 import pytest
-from scipy.linalg import schur
 from scipy.stats import ortho_group
 
 

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -165,6 +165,18 @@ def test_two_sided_orthogonal_identical(n):
     assert_almost_equal(result.error, 0., decimal=6)
 
 
+def test_orthogonal_raises_error():
+    r"""Test that orthogonal with incorrect shape raises error"""
+    array_a = np.random.uniform(-10.0, 10.0, (10, 20))
+    array_b = array_a.copy()
+    array_b = np.concatenate((array_b, np.zeros((10, 5))), axis=1)
+    array_b = np.concatenate((array_b, np.zeros((3, 25))), axis=0)
+    assert_raises(ValueError, orthogonal, array_a, array_b, unpad_col=False, pad=False)
+    assert_raises(ValueError, orthogonal, array_a, array_b, unpad_row=False, pad=False)
+    assert_raises(ValueError, orthogonal, array_a, array_b, unpad_col=False, unpad_row=False,
+                  pad=False)
+
+
 def test_two_sided_orthogonal_raises_error_non_symmetric_matrices():
     r"""Test that 2-sided orthogonal procrustes non-symmetric matrices raises an error."""
     # Test simple example with one matrix that is not square

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -307,27 +307,6 @@ def test_two_sided_orthogonal_single_transformation_with_scaling(n):
     assert_almost_equal(result.error, 0, decimal=8)
 
 
-def test_two_sided_orthogonal_single_transformation_scale_rot_ref_3by3():
-    r"""Test 2sided orthogonal by 3by3 array with single translation, scling and rotation."""
-    # define an arbitrary symmetric array
-    array_a = (np.random.rand(3, 3) * 100).astype(int)
-    array_a = np.dot(array_a, array_a.T)
-    # define transformation composed of rotation and reflection
-    theta = 5.7 * np.pi / 21.95
-    rot = np.array([[np.cos(theta), -np.sin(theta), 0.],
-                    [np.sin(theta), np.cos(theta), 0.], [0., 0., 1.]])
-    ref = np.array([[1., 0., 0.], [0., -1., 0.], [0., 0., 1.]])
-    trans = np.dot(ref, rot)
-    # define array_b by transforming scaled array_a
-    array_b = np.dot(np.dot(trans.T, 6.9 * array_a), trans)
-
-    # check transformation array and error
-    result = orthogonal_2sided(array_a, array_b, single_transform=True, translate=False, scale=True)
-    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(3), decimal=8)
-    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=8)
-    assert_almost_equal(result["error"], 0, decimal=8)
-
-
 def test_two_sided_orthogonal_single_transformation_random_orthogonal():
     r"""Test 2sided orthogonal by 3by3 array."""
     # define random array

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -44,11 +44,11 @@ def test_procrustes_orthogonal_identical(m, n):
     array_a = np.random.uniform(-10.0, 10.0, (m, n))
     array_b = np.copy(array_a)
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["new_a"], array_a, decimal=6)
-    assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_almost_equal(res["t"].dot(res["t"].T), np.eye(n), decimal=6)
-    assert_almost_equal(res["error"], 0., decimal=6)
-    assert_almost_equal(array_a.dot(res["t"]), array_b)
+    assert_almost_equal(res.new_a, array_a, decimal=6)
+    assert_almost_equal(res.new_b, array_b, decimal=6)
+    assert_almost_equal(res.t.dot(res.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(res.error, 0., decimal=6)
+    assert_almost_equal(array_a.dot(res.t), array_b)
 
 
 @pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
@@ -60,9 +60,9 @@ def test_procrustes_rotation_square(n):
     ortho_arr = ortho_group.rvs(n)
     array_b = array_a.dot(ortho_arr)
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["error"], 0., decimal=6)
-    assert_almost_equal(res["t"].dot(res["t"].T), np.eye(n), decimal=6)
-    assert_almost_equal(res["t"], ortho_arr)
+    assert_almost_equal(res.error, 0., decimal=6)
+    assert_almost_equal(res.t.dot(res.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(res.t, ortho_arr)
 
 
 @pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
@@ -73,18 +73,18 @@ def test_procrustes_reflection_square(n):
     # reflection through diagonal plane
     array_b = -array_a
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["new_a"], array_a, decimal=6)
-    assert_almost_equal(res["new_b"], array_b, decimal=6)
-    assert_almost_equal(res["t"], -np.eye(n), decimal=6)
-    assert_almost_equal(res["error"], 0., decimal=6)
+    assert_almost_equal(res.new_a, array_a, decimal=6)
+    assert_almost_equal(res.new_b, array_b, decimal=6)
+    assert_almost_equal(res.t, -np.eye(n), decimal=6)
+    assert_almost_equal(res.error, 0., decimal=6)
     # General reflection through random hyperplane, see Wikipedia "Reflection (mathematics)"
     a = np.random.uniform(-10.0, 10.0, (n))
     a /= np.linalg.norm(a)
     rotation = np.eye(n) - 2.0 * np.outer(a, a) / np.linalg.norm(a)**2.0
     array_b = array_a.dot(rotation)
     res = orthogonal(array_a, array_b)
-    assert_almost_equal(res["t"], rotation, decimal=6)
-    assert_almost_equal(res["error"], 0., decimal=6)
+    assert_almost_equal(res.t, rotation, decimal=6)
+    assert_almost_equal(res.error, 0., decimal=6)
     assert_almost_equal(array_a.dot(rotation), array_b, decimal=6)
 
 
@@ -95,12 +95,12 @@ def test_procrustes_with_translation(m, n):
     array_b = array_a + np.random.uniform(-10.0, 10.0, (n,))
     res = orthogonal(array_a, array_b, translate=True)
     # Test that the new A and B are translation of the originals.
-    assert_almost_equal(res["new_a"], array_a - np.mean(array_a, axis=0), decimal=6)
-    assert_almost_equal(res["new_b"], array_a - np.mean(array_a, axis=0), decimal=6)
+    assert_almost_equal(res.new_a, array_a - np.mean(array_a, axis=0), decimal=6)
+    assert_almost_equal(res.new_b, array_a - np.mean(array_a, axis=0), decimal=6)
     # Test that optimal result is orthogonal, and error is zero
-    assert_almost_equal(res["t"].T.dot(res["t"]), np.eye(n), decimal=6)
-    assert_almost_equal(res["error"], 0., decimal=6)
-    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
+    assert_almost_equal(res.t.T.dot(res.t), np.eye(n), decimal=6)
+    assert_almost_equal(res.error, 0., decimal=6)
+    assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
@@ -118,10 +118,10 @@ def test_orthogonal_with_translate_and_scale(m, n):
     # Procrustes with translation and scaling
     res = orthogonal(array_a, array_b, translate=True, scale=True)
     untranslated_array_a = (array_a - np.mean(array_a, axis=0))
-    assert_almost_equal(res["new_a"], untranslated_array_a / np.linalg.norm(untranslated_array_a))
-    assert_almost_equal(res["t"].T.dot(res["t"]), np.eye(n), decimal=6)
-    assert_almost_equal(res["error"], 0., decimal=6)
-    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
+    assert_almost_equal(res.new_a, untranslated_array_a / np.linalg.norm(untranslated_array_a))
+    assert_almost_equal(res.t.T.dot(res.t), np.eye(n), decimal=6)
+    assert_almost_equal(res.error, 0., decimal=6)
+    assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
 
 
 @pytest.mark.parametrize("m, n, ncols, nrows", np.random.randint(50, 100, (25, 4)))
@@ -138,10 +138,10 @@ def test_orthogonal_translate_scale_with_unpadding(m, n, ncols, nrows):
     array_b = np.concatenate((array_b, np.zeros((nrows, n + ncols))), axis=0)
     # compute procrustes transformation
     res = orthogonal(array_a, array_b, translate=False, scale=False, unpad_col=True, unpad_row=True)
-    assert_almost_equal(res["new_b"], np.dot(array_a, ortho), decimal=6)
-    assert_almost_equal(res["error"], 0., decimal=6)
-    assert_almost_equal(res["t"].T.dot(res["t"]), np.eye(n), decimal=6)
-    assert_almost_equal(res["new_a"].dot(res["t"]), res["new_b"], decimal=6)
+    assert_almost_equal(res.new_b, np.dot(array_a, ortho), decimal=6)
+    assert_almost_equal(res.error, 0., decimal=6)
+    assert_almost_equal(res.t.T.dot(res.t), np.eye(n), decimal=6)
+    assert_almost_equal(res.new_a.dot(res.t), res.new_b, decimal=6)
 
 
 @pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
@@ -152,11 +152,11 @@ def test_two_sided_orthogonal_identical(n):
     array_b = np.copy(array_a)
     result = orthogonal_2sided(array_a, array_b, single_transform=False)
     # check transformation array is identity
-    assert_almost_equal(np.linalg.det(result["s"]), 1.0, decimal=6)
-    assert_almost_equal(np.linalg.det(result["t"]), 1.0, decimal=6)
-    assert_almost_equal(result["s"], np.eye(n), decimal=6)
-    assert_almost_equal(result["t"], np.eye(n), decimal=6)
-    assert_almost_equal(result["error"], 0., decimal=6)
+    assert_almost_equal(np.linalg.det(result.s), 1.0, decimal=6)
+    assert_almost_equal(np.linalg.det(result.t), 1.0, decimal=6)
+    assert_almost_equal(result.s, np.eye(n), decimal=6)
+    assert_almost_equal(result.t, np.eye(n), decimal=6)
+    assert_almost_equal(result.error, 0., decimal=6)
 
 
 def test_two_sided_orthogonal_raises_error_non_symmetric_matrices():
@@ -195,18 +195,16 @@ def test_two_sided_orthogonal_rotate_reflect(m, n):
     # compute procrustes transformation
     result = orthogonal_2sided(array_a, array_b, single_transform=False)
     # check transformation array orthogonality
-    assert_almost_equal(np.dot(result["s"], result["s"].T), np.eye(m), decimal=6)
-    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(n), decimal=6)
-    assert_almost_equal(result["s"].T.dot(result["new_a"].dot(result["t"])),
-                        result["new_b"], decimal=6)
-    assert_almost_equal(result["error"], 0, decimal=6)
+    assert_almost_equal(np.dot(result.s, result.s.T), np.eye(m), decimal=6)
+    assert_almost_equal(np.dot(result.t, result.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(result.error, 0, decimal=6)
 
 
 @pytest.mark.parametrize("m, n, ncols, nrows", np.random.randint(50, 100, (25, 4)))
 def test_two_sided_orthogonal_rotate_with_unpadding(m, n, ncols, nrows):
     r"""Test two sided orthogonal with unpadding."""
     # define an arbitrary array
-    array_a = np.random.uniform(-10.0, 10.0, (n, n))
+    array_a = np.random.uniform(-10.0, 10.0, (m, n))
     # define rotation and reflection arrays
     rot = ortho_group.rvs(n)
     array_b = np.dot(array_a, rot)
@@ -217,11 +215,11 @@ def test_two_sided_orthogonal_rotate_with_unpadding(m, n, ncols, nrows):
     result = orthogonal_2sided(array_a, array_b, single_transform=False, translate=True, scale=True,
                                unpad_col=True, unpad_row=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(result["s"], result["s"].T), np.eye(m), decimal=6)
-    assert_almost_equal(np.dot(result["t"], result["t"].T), np.eye(n), decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["s"])), 1.0, decimal=6)
-    assert_almost_equal(abs(np.linalg.det(result["t"])), 1.0, decimal=6)
-    assert_almost_equal(result["error"], 0, decimal=6)
+    assert_almost_equal(np.dot(result.s, result.s.T), np.eye(m), decimal=6)
+    assert_almost_equal(np.dot(result.t, result.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result.s)), 1.0, decimal=6)
+    assert_almost_equal(abs(np.linalg.det(result.t)), 1.0, decimal=6)
+    assert_almost_equal(result.error, 0, decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))


### PR DESCRIPTION
This pull request refactors the test in orthogonal.py to make the matrix sizes, orthogonal matrices, translation and padding length to be randomized . It generates a random orthogonal matrix via scipy.stats.ortho_group class.

Some tests were removed because they weren't that much different to the previous tests (a7a1b27,  a7e4e72, f9673c4).
Also added "assert(res.s, None)" and removed the dictionary call of results (5361ceb,  67b15b4).
I removed the term unitary from the function document because all unitary matrices here are orthogonal because singular value decomposition of real-valued matrices contain orthogonal matrices and likewise with eigenvalue decomposition of real, symmetric matrices (7c1dc37).
Added a test for incorrect inputs increasing the code coverage (6c3066a).

I will rebase when the previous pull requests goes through, so that it will pass continuous integration.