### PR TITLE
Change svd

### DIFF
--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -26,6 +26,7 @@
 
 import numpy as np
 from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
+import scipy
 
 __all__ = [
     "orthogonal",
@@ -345,8 +346,8 @@ def orthogonal_2sided(
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=u_opt, s=u_opt.T)
 
     # two-sided orthogonal Procrustes with two-transformations
-    ua, _, vta = np.linalg.svd(new_a)
-    ub, _, vtb = np.linalg.svd(new_b)
+    ua, _, vta = scipy.linalg.svd(new_a, lapack_driver="gesvd")
+    ub, _, vtb = scipy.linalg.svd(new_b, lapack_driver="gesvd")
     u_opt1 = np.dot(ua, ub.T)
     u_opt2 = np.dot(vta.T, vtb)
     error = compute_error(new_a, new_b, u_opt2, u_opt1.T)

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -144,7 +144,7 @@ def orthogonal(
             "Check pad, remove_zero_col, and remove_zero_row arguments."
         )
     # calculate SVD of A.T * B
-    u, _, vt = np.linalg.svd(np.dot(new_a.T, new_b))
+    u, _, vt = scipy.linalg.svd(np.dot(new_a.T, new_b), lapack_driver="gesvd")
     # compute optimal orthogonal transformation
     u_opt = np.dot(u, vt)
     # compute one-sided error

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -27,6 +27,7 @@ import itertools as it
 import numpy as np
 from procrustes.kopt import kopt_heuristic_double, kopt_heuristic_single
 from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
+import scipy
 from scipy.optimize import linear_sum_assignment
 
 __all__ = ["permutation", "permutation_2sided", "permutation_2sided_explicit"]
@@ -607,7 +608,7 @@ def _2sided_1trans_initial_guess_umeyama_approx(array_a, array_b, add_noise):
     # compute U_umeyama
     array_u = _2sided_1trans_initial_guess_umeyama(array_a, array_b, add_noise)
     # calculate the approximated umeyama matrix
-    array_ua, _, array_vta = np.linalg.svd(array_u)
+    array_ua, _, array_vta = scipy.linalg.svd(array_u, lapack_driver='gesvd')
     u_approx = np.dot(np.abs(array_ua), np.abs(array_vta))
     # compute closest unitary transformation to U
     # _, _, U, _ = permutation(np.eye(U.shape[0], dtype=U.dtype), U)

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -24,6 +24,7 @@
 
 import numpy as np
 from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
+import scipy
 
 
 def rotational(
@@ -158,7 +159,7 @@ def rotational(
             "Check pad, remove_zero_col, and remove_zero_row arguments."
         )
     # compute SVD of A.T * B
-    u, _, vt = np.linalg.svd(np.dot(new_a.T, new_b))
+    u, _, vt = scipy.linalg.svd(np.dot(new_a.T, new_b), lapack_driver='gesvd')
     # construct S: an identity matrix with the smallest singular value replaced by sgn(|U*V^t|)
     s = np.eye(new_a.shape[1])
     s[-1, -1] = np.sign(np.linalg.det(np.dot(u, vt)))

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -25,6 +25,7 @@
 import numpy as np
 from procrustes.utils import _zero_padding
 from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
+import scipy
 
 
 def symmetric(
@@ -169,7 +170,7 @@ def symmetric(
     #     raise ValueError(f"Shape of B {new_b.shape}=(m, n) needs to satisfy m >= n.")
 
     # compute SVD of A
-    u, s, vt = np.linalg.svd(new_a)
+    u, s, vt = scipy.linalg.svd(new_a, lapack_driver='gesvd')
 
     c = np.dot(np.dot(u.T, new_b), vt.T)
     # create the intermediate array Y and the optimum symmetric transformation array X


### PR DESCRIPTION
This short pull request changes from Numpy SVD function to Scipy SVD function. See issue #69 for more info as to why this choose was made.

These changes were made to orthogonal, permutation, rotational, and symmetric. I was thinking of adding a function variable "lapack_driver" to each of these functions with docstring
`
"lapack_driver : {"gesvd", "gesdd"}, optional
        Used in the singular value decomposition function from SciPy. Only allowed two options, with
        "gesvd" being less-efficient than "gesdd" but is more robust. Default is "gesvd".
`
Any thoughts @FarnazH 