### PR TITLE
Refactor kopt

### DIFF
--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -53,7 +53,7 @@ def kopt_heuristic_single(fun, p0, k=3):
     fun : callable
         The objective function :math:`f` to be minimized.
     p0 : ndarray
-        The 2D-array :math:`\mathbf{P}` representing the initial permutation matrix.
+        The 2D-array permutation matrix representing the initial guess for :math:`\mathbf{P}`.
     k : int, optional
         The order of the permutation. For example, `k=3` swaps all possible 3-permutations.
 
@@ -102,34 +102,30 @@ def kopt_heuristic_single(fun, p0, k=3):
     return p0, error
 
 
-def kopt_heuristic_double(a, b, p1=None, p2=None, k=3):
+def kopt_heuristic_double(fun, p1=None, p2=None, k=3):
     r"""Find a locally-optimal two-sided permutation matrices using the k-opt (greedy) heuristic.
 
     .. math::
-        &\underbrace{\text{min}}_{\left\{\mathbf{P}_1,\mathbf{P}_2 \left|
-        {[\mathbf{P}_1]_{ij} \in \{0, 1\} \atop \sum_{i=1}^n [\mathbf{P}_1]_{ij} = \sum_{j=1}^n [
-        \mathbf{P}_1]_{ij} = 1} \atop {[\mathbf{P}_2]_{ij} \in \{0, 1\} \atop \sum_{i=1}^n [
-        \mathbf{P}_2]_{ij} = \sum_{j=1}^n [\mathbf{P}_2]_{ij} = 1} \right. \right\}}
-            \|\mathbf{P}_1 \mathbf{A} \mathbf{P}_2 - \mathbf{B}\|_{F}^2\\
+        \underbrace{\text{arg min}}_{\left\{ {\mathbf{P}_1, \mathbf{P}_2} \left|
+        {[\mathbf{P}_1]_{ij} \in \{0, 1\} \text{and} [\mathbf{P}_2]_{ij} \in \{0, 1\} \atop
+         \sum_{i=1}^m [\mathbf{P}_1]_{ij} = \sum_{j=1}^m [\mathbf{P}_1]_{ij} = 1 \atop
+         \sum_{i=1}^n [\mathbf{P}_2]_{ij} = \sum_{j=1}^n [\mathbf{P}_2]_{ij} = 1} \right. \right\}}
+         f(\mathbf{P}_1, \mathbf{P}_2)
 
     All possible 2-, ..., k-fold permutations of the initial permutation matrices are tried to
-    identify ones which give a lower error. This corresponds to row-swaps for :math:`\mathbf{
-    P}_1` and column-swaps for :math:`\mathbf{P}_2`. Starting from these updated permutation
-    matrices, the process is repeated until no further k-fold reordering of either permutation
-    matrix lower the error.
+    identify ones which give a lower value of objective function :math:`f`.
+    This corresponds to row-swaps for :math:`\mathbf{ P}_1` and column-swaps for :math:`\mathbf{
+    P}_2`. Starting from these updated permutation matrices, the process is repeated until no
+    further k-fold reordering of either permutation matrix lower the objective function.
 
     Parameters
     ----------
-    a : ndarray
-        The 2D-array :math:`\mathbf{A}` which is going to be transformed.
-    b : ndarray
-        The 2D-array :math:`\mathbf{B}` representing the reference matrix.
-    p1 : ndarray, optional
-        The 2D-array :math:`\mathbf{P}_1` representing the initial left-hand-side permutation
-        matrix. If ``None``, the identity matrix is used.
-    p2 : ndarray, optional
-        The 2D-array :math:`\mathbf{P}_2` representing the initial right-hand-side permutation
-        matrix. If ``None``, the identity matrix is used.
+    fun : callable
+        The objective function :math:`f` to be minimized.
+    p1 : ndarray
+        The 2D-array permutation matrix representing the initial guess for :math:`\mathbf{P}_1`.
+    p2 : ndarray
+        The 2D-array permutation matrix representing the initial guess for :math:`\mathbf{P}_2`.
     k : int, optional
         The order of the permutation. For example, ``k=3`` swaps all possible 3-permutations.
 
@@ -139,29 +135,40 @@ def kopt_heuristic_double(a, b, p1=None, p2=None, k=3):
         The locally-optimal left-hand-side permutation matrix.
     perm_p2 : ndarray
         The locally-optimal right-hand-side permutation matrix.
-    error : float
-        The locally-optimal error.
+    fun : float
+        The locally-optimal value of the objective function.
 
     """
+    # check whether p1 & p2 are square arrays
+    if p1.ndim != 2 or p1.shape[0] != p1.shape[1]:
+        raise ValueError(f"Argument p1 should be a square array. Given p1 shape={p1.shape}")
+    if p2.ndim != 2 or p2.shape[0] != p2.shape[1]:
+        raise ValueError(f"Argument p2 should be a square array. Given p2 shape={p2.shape}")
+
+    # check whether p1 & p2 are valid permutation matrices
+    if not np.all(np.logical_or(p1 == 0, p1 == 1)):
+        raise ValueError("Elements of permutation matrix p1 can only be 0 or 1.")
+    if not np.all(np.logical_or(p2 == 0, p2 == 1)):
+        raise ValueError("Elements of permutation matrix p2 can only be 0 or 1.")
+
+    if np.all(np.sum(p1, axis=0) != 1) or np.all(np.sum(p1, axis=1) != 1):
+        raise ValueError("Sum over rows or columns of p1 matrix isn't equal 1.")
+    if np.all(np.sum(p2, axis=0) != 1) or np.all(np.sum(p2, axis=1) != 1):
+        raise ValueError("Sum over rows or columns of p2 matrix isn't equal 1.")
+
+    # check k
     if k < 2 or not isinstance(k, int):
         raise ValueError(f"Argument k must be a integer greater than 2. Given k={k}")
-    if a.shape != b.shape:
-        raise ValueError(f"Argument b should have same shape as a. Given {b.shape} != {a.shape}")
-
-    # assign p1 & p2 to be an identity arrays, if not specified
-    n, m = a.shape
-    if p1 is None:
-        p1 = np.identity(n)
-    if p2 is None:
-        p2 = np.identity(m)
+    if k > min(p1.shape[0], p2.shape[0]):
+        raise ValueError(f"Argument k={k} is not smaller than {min(p1.shape[0], p2.shape[0])}.")
 
     # compute 2-sided permutation error of the initial P & Q matrices
-    error = compute_error(a, b, p2, p1.T)
+    error = fun(p1, p2)
     # pylint: disable=too-many-nested-blocks
 
-    for perm1 in it.permutations(np.arange(n), r=k):
+    for perm1 in it.permutations(np.arange(p1.shape[0]), r=k):
         comb1 = tuple(sorted(perm1))
-        for perm2 in it.permutations(np.arange(m), r=k):
+        for perm2 in it.permutations(np.arange(p2.shape[0]), r=k):
             comb2 = tuple(sorted(perm2))
             if not (perm1 == comb1 and perm2 == comb2):
                 # permute rows of matrix P1
@@ -171,7 +178,7 @@ def kopt_heuristic_double(a, b, p1=None, p2=None, k=3):
                 perm_p2 = np.copy(p2)
                 perm_p2[comb2, :] = perm_p2[perm2, :]
                 # compute error with new matrices & compare
-                perm_error = compute_error(b, a, perm_p2, perm_p1.T)
+                perm_error = fun(perm_p1, perm_p2)
                 if perm_error < error:
                     p1, p2, error = perm_p1, perm_p2, perm_error
                     # check whether perfect permutation matrix is found

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -99,8 +99,10 @@ def kopt_heuristic_single(fun, p0, k=3):
                 # compute objective function for permuted P matrix & compare
                 perm_f = fun(perm_p)
                 if perm_f < best_f:
-                    search = True
                     best_p, best_f = perm_p, perm_f
+                    # set search=True to keep permuting the new best_p unless this is already an
+                    # exhaustive search (i.e., k equals number of rows of p matrix)
+                    search = True if k < p0.shape[0] else False
                     # check whether perfect permutation matrix is found
                     # TODO: smarter threshold based on norm of matrix
                     if best_f <= 1.0e-8:
@@ -195,8 +197,10 @@ def kopt_heuristic_double(fun, p1, p2, k=3):
                     # compute objective function for permuted P matrix & compare
                     perm_f = fun(perm_p1, perm_p2)
                     if perm_f < best_f:
-                        search = True
                         best_p1, best_p2, best_f = perm_p1, perm_p2, perm_f
+                        # set search=True to keep permuting the new best_p1 & best_p2 unless this
+                        # is already an exhaustive search
+                        search = True if k < max(p1.shape[0], p2.shape[0]) else False
                         # check whether perfect permutation matrix is found
                         # TODO: smarter threshold based on norm of matrix
                         if best_f <= 1.0e-8:

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -77,7 +77,7 @@ def kopt_heuristic_single(fun, p0, k=3):
 
     # check k
     if k < 2 or not isinstance(k, (int, np.integer)):
-        raise ValueError(f"Argument k must be a integer greater than 2. Given k={k}")
+        raise ValueError(f"Argument k must be a integer greater than 1. Given k={k}")
     if k > p0.shape[0]:
         raise ValueError(f"Argument k={k} is not smaller than {p0.shape[0]} (number of p0 rows).")
 
@@ -108,7 +108,7 @@ def kopt_heuristic_single(fun, p0, k=3):
     return best_p, best_f
 
 
-def kopt_heuristic_double(fun, p1=None, p2=None, k=3):
+def kopt_heuristic_double(fun, p1, p2, k=3):
     r"""Find a locally-optimal two-sided permutation matrices using the k-opt (greedy) heuristic.
 
     .. math::
@@ -167,7 +167,7 @@ def kopt_heuristic_double(fun, p1=None, p2=None, k=3):
 
     # check k
     if k < 2 or not isinstance(k, (int, np.integer)):
-        raise ValueError(f"Argument k must be a integer greater than 2. Given k={k}")
+        raise ValueError(f"Argument k must be a integer greater than 1. Given k={k}")
     if k > max(p1.shape[0], p2.shape[0]):
         raise ValueError(f"Argument k={k} is not smaller than {max(p1.shape[0], p2.shape[0])}.")
 

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -112,11 +112,12 @@ def kopt_heuristic_double(fun, p1=None, p2=None, k=3):
     r"""Find a locally-optimal two-sided permutation matrices using the k-opt (greedy) heuristic.
 
     .. math::
-        \underbrace{\text{arg min}}_{\left\{ {\mathbf{P}_1, \mathbf{P}_2} \left|
-        {[\mathbf{P}_1]_{ij} \in \{0, 1\} \text{and} [\mathbf{P}_2]_{ij} \in \{0, 1\} \atop
-         \sum_{i=1}^m [\mathbf{P}_1]_{ij} = \sum_{j=1}^m [\mathbf{P}_1]_{ij} = 1 \atop
-         \sum_{i=1}^n [\mathbf{P}_2]_{ij} = \sum_{j=1}^n [\mathbf{P}_2]_{ij} = 1} \right. \right\}}
-         f(\mathbf{P}_1, \mathbf{P}_2)
+        \underbrace{\text{arg min}}_{
+        \left\{ {\mathbf{P}_1, \mathbf{P}_2} \left|
+        {{[\mathbf{P}_1]_{ij} \in \{0, 1\} \atop [\mathbf{P}_2]_{ij} \in \{0, 1\}} \atop
+        {\sum_{i=1}^m [\mathbf{P}_1]_{ij} = \sum_{j=1}^m [\mathbf{P}_1]_{ij} = 1 \atop
+        \sum_{i=1}^n [\mathbf{P}_2]_{ij} = \sum_{j=1}^n [\mathbf{P}_2]_{ij} = 1}} \right. \right\}}
+        f(\mathbf{P}_1, \mathbf{P}_2)
 
     All possible 2-, ..., k-fold permutations of the initial permutation matrices are tried to
     identify ones which give a lower value of objective function :math:`f`.

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -172,23 +172,28 @@ def kopt_heuristic_double(fun, p1=None, p2=None, k=3):
     best_f = fun(p1, p2)
     best_p1, best_p2 = np.copy(p1), np.copy(p2)
 
-    for perm1 in it.permutations(np.arange(p1.shape[0]), r=min(k, p1.shape[0])):
-        comb1 = tuple(sorted(perm1))
-        for perm2 in it.permutations(np.arange(p2.shape[0]), r=min(k, p2.shape[0])):
-            comb2 = tuple(sorted(perm2))
-            if not (perm1 == comb1 and perm2 == comb2):
-                # permute rows of matrix P1
-                perm_p1 = np.copy(p1)
-                perm_p1[comb1, :] = perm_p1[perm1, :]
-                # permute rows of matrix P2
-                perm_p2 = np.copy(p2)
-                perm_p2[comb2, :] = perm_p2[perm2, :]
-                # compute objective function for permuted P matrix & compare
-                perm_f = fun(perm_p1, perm_p2)
-                if perm_f < best_f:
-                    best_p1, best_p2, best_f = perm_p1, perm_p2, perm_f
-                    # check whether perfect permutation matrix is found
-                    # TODO: smarter threshold based on norm of matrix
-                    if best_f <= 1.0e-8:
-                        return best_p1, best_p2, best_f
+    # swap rows and columns until the permutation matrix is not improved
+    search = True
+    while search:
+        search = False
+        for perm1 in it.permutations(np.arange(p1.shape[0]), r=min(k, p1.shape[0])):
+            comb1 = tuple(sorted(perm1))
+            for perm2 in it.permutations(np.arange(p2.shape[0]), r=min(k, p2.shape[0])):
+                comb2 = tuple(sorted(perm2))
+                if not (perm1 == comb1 and perm2 == comb2):
+                    # permute rows of matrix P1
+                    perm_p1 = np.copy(p1)
+                    perm_p1[comb1, :] = perm_p1[perm1, :]
+                    # permute rows of matrix P2
+                    perm_p2 = np.copy(p2)
+                    perm_p2[comb2, :] = perm_p2[perm2, :]
+                    # compute objective function for permuted P matrix & compare
+                    perm_f = fun(perm_p1, perm_p2)
+                    if perm_f < best_f:
+                        search = True
+                        best_p1, best_p2, best_f = perm_p1, perm_p2, perm_f
+                        # check whether perfect permutation matrix is found
+                        # TODO: smarter threshold based on norm of matrix
+                        if best_f <= 1.0e-8:
+                            return best_p1, best_p2, best_f
     return best_p1, best_p2, best_f

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -101,7 +101,7 @@ def kopt_heuristic_single(fun, p0, k=3):
                     best_p, best_f = perm_p, perm_f
                     # set search=True to keep permuting the new best_p unless this is already an
                     # exhaustive search (i.e., k equals number of rows of p matrix)
-                    search = True if k < p0.shape[0] else False
+                    search = bool(k < p0.shape[0])
                     # check whether perfect permutation matrix is found
                     # TODO: smarter threshold based on norm of matrix
                     if best_f <= 1.0e-8:
@@ -199,7 +199,7 @@ def kopt_heuristic_double(fun, p1, p2, k=3):
                         best_p1, best_p2, best_f = perm_p1, perm_p2, perm_f
                         # set search=True to keep permuting the new best_p1 & best_p2 unless this
                         # is already an exhaustive search
-                        search = True if k < max(p1.shape[0], p2.shape[0]) else False
+                        search = bool(k < max(p1.shape[0], p2.shape[0]))
                         # check whether perfect permutation matrix is found
                         # TODO: smarter threshold based on norm of matrix
                         if best_f <= 1.0e-8:

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -26,7 +26,6 @@
 import itertools as it
 
 import numpy as np
-from procrustes.utils import compute_error
 
 
 __all__ = [

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -34,7 +34,7 @@ __all__ = [
 ]
 
 
-def kopt_heuristic_single(fun, p0, k=3):
+def kopt_heuristic_single(fun, p0, k=3, tol=1.0e-8):
     r"""Find a locally-optimal permutation matrix using the k-opt (greedy) heuristic.
 
     .. math::
@@ -55,13 +55,15 @@ def kopt_heuristic_single(fun, p0, k=3):
         The 2D-array permutation matrix representing the initial guess for :math:`\mathbf{P}`.
     k : int, optional
         The order of the permutation. For example, `k=3` swaps all possible 3-permutations.
+    tol : float, optional
+        When value of the objective function is less than given tolerance, the algorithm stops.
 
     Returns
     -------
-    p : ndarray
+    p_opt : ndarray
         The locally-optimal permutation matrix :math:`\mathbf{P}` (i.e., solution).
-    fun : float
-        The locally-optimal value of the objective function.
+    f_opt : float
+        The locally-optimal value of objective function given by :math:`\text{fun(p_opt)}`.
 
     """
     # pylint: disable=too-many-nested-blocks
@@ -104,12 +106,12 @@ def kopt_heuristic_single(fun, p0, k=3):
                     search = bool(k < p0.shape[0])
                     # check whether perfect permutation matrix is found
                     # TODO: smarter threshold based on norm of matrix
-                    if best_f <= 1.0e-8:
+                    if best_f <= tol:
                         return best_p, best_f
     return best_p, best_f
 
 
-def kopt_heuristic_double(fun, p1, p2, k=3):
+def kopt_heuristic_double(fun, p1, p2, k=3, tol=1.0e-8):
     r"""Find a locally-optimal two-sided permutation matrices using the k-opt (greedy) heuristic.
 
     .. math::
@@ -136,15 +138,17 @@ def kopt_heuristic_double(fun, p1, p2, k=3):
         The 2D-array permutation matrix representing the initial guess for :math:`\mathbf{P}_2`.
     k : int, optional
         The order of the permutation. For example, ``k=3`` swaps all possible 3-permutations.
+    tol : float, optional
+        When value of the objective function is less than given tolerance, the algorithm stops.
 
     Returns
     -------
-    perm_p1 : ndarray
+    p1_opt : ndarray
         The locally-optimal permutation matrix :math:`\mathbf{P}_1`.
-    perm_p2 : ndarray
+    p2_opt : ndarray
         The locally-optimal permutation matrix :math:`\mathbf{P}_2`.
-    fun : float
-        The locally-optimal value of the objective function.
+    f_opt : float
+        The locally-optimal value of objective function given by :math:`\text{fun(p1_opt, p2_opt)}`.
 
     """
     # pylint: disable=too-many-nested-blocks
@@ -202,6 +206,6 @@ def kopt_heuristic_double(fun, p1, p2, k=3):
                         search = bool(k < max(p1.shape[0], p2.shape[0]))
                         # check whether perfect permutation matrix is found
                         # TODO: smarter threshold based on norm of matrix
-                        if best_f <= 1.0e-8:
+                        if best_f <= tol:
                             return best_p1, best_p2, best_f
     return best_p1, best_p2, best_f

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -68,10 +68,16 @@ def kopt_heuristic_single(fun, p0, k=3):
     # pylint: disable=too-many-nested-blocks
     if k < 2 or not isinstance(k, int):
         raise ValueError(f"Argument k must be a integer greater than 2. Given k={k}")
-    if p0.shape[0] != p0.shape[1]:
+    if p0.ndim != 2 or p0.shape[0] != p0.shape[1]:
         raise ValueError(f"Argument p0 should be a square array. Given p0 shape={p0.shape}")
     if k > p0.shape[0]:
-        raise ValueError("Argument k should be smaller than p0 rows. Given {k} > {p0.shape[0]}")
+        raise ValueError(f"Argument k={k} is not smaller than {p0.shape[0]} (number of p0 rows).")
+
+    # check whether p0 is a valid permutation matrix
+    if not np.all(np.logical_or(p0 == 0, p0 == 1)):
+        raise ValueError("Elements of permutation matrix p0 can only be 0 or 1.")
+    if np.all(np.sum(p0, axis=0) != 1) or np.all(np.sum(p0, axis=1) != 1):
+        raise ValueError("Sum over rows or columns of p0 matrix isn't equal 1.")
 
     # compute initial value of the objective function
     error = fun(p0)

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -88,6 +88,8 @@ def kopt_heuristic_single(fun, p0, k=3):
     search = True
     while search:
         search = False
+        # make sure p0 guess is the best permutation matrix found thus far
+        p0 = np.copy(best_p)
         for perm in it.permutations(np.arange(p0.shape[0]), r=k):
             comb = tuple(sorted(perm))
             if perm != comb:
@@ -176,6 +178,8 @@ def kopt_heuristic_double(fun, p1=None, p2=None, k=3):
     search = True
     while search:
         search = False
+        # make sure p1 & p2 guesses are the best permutation matrices found thus far
+        p1, p2 = np.copy(best_p1), np.copy(best_p2)
         for perm1 in it.permutations(np.arange(p1.shape[0]), r=min(k, p1.shape[0])):
             comb1 = tuple(sorted(perm1))
             for perm2 in it.permutations(np.arange(p2.shape[0]), r=min(k, p2.shape[0])):

--- a/procrustes/kopt.py
+++ b/procrustes/kopt.py
@@ -77,7 +77,7 @@ def kopt_heuristic_single(fun, p0, k=3):
 
     # check k
     if k < 2 or not isinstance(k, (int, np.integer)):
-        raise ValueError(f"Argument k must be a integer greater than 1. Given k={k}")
+        raise ValueError(f"Argument k={k} must be a integer greater than 1. Given type {type(k)}")
     if k > p0.shape[0]:
         raise ValueError(f"Argument k={k} is not smaller than {p0.shape[0]} (number of p0 rows).")
 
@@ -90,7 +90,7 @@ def kopt_heuristic_single(fun, p0, k=3):
         search = False
         # make sure p0 guess is the best permutation matrix found thus far
         p0 = np.copy(best_p)
-        for perm in it.permutations(np.arange(p0.shape[0]), r=k):
+        for perm in it.permutations(np.arange(p0.shape[0]), r=int(k)):
             comb = tuple(sorted(perm))
             if perm != comb:
                 # row-swap P matrix & compute objective function
@@ -169,7 +169,7 @@ def kopt_heuristic_double(fun, p1, p2, k=3):
 
     # check k
     if k < 2 or not isinstance(k, (int, np.integer)):
-        raise ValueError(f"Argument k must be a integer greater than 1. Given k={k}")
+        raise ValueError(f"Argument k={k} must be a integer greater than 1. Give type {type(k)}")
     if k > max(p1.shape[0], p2.shape[0]):
         raise ValueError(f"Argument k={k} is not smaller than {max(p1.shape[0], p2.shape[0])}.")
 
@@ -183,9 +183,9 @@ def kopt_heuristic_double(fun, p1, p2, k=3):
         search = False
         # make sure p1 & p2 guesses are the best permutation matrices found thus far
         p1, p2 = np.copy(best_p1), np.copy(best_p2)
-        for perm1 in it.permutations(np.arange(p1.shape[0]), r=min(k, p1.shape[0])):
+        for perm1 in it.permutations(np.arange(p1.shape[0]), r=int(min(k, p1.shape[0]))):
             comb1 = tuple(sorted(perm1))
-            for perm2 in it.permutations(np.arange(p2.shape[0]), r=min(k, p2.shape[0])):
+            for perm2 in it.permutations(np.arange(p2.shape[0]), r=int(min(k, p2.shape[0]))):
                 comb2 = tuple(sorted(perm2))
                 if not (perm1 == comb1 and perm2 == comb2):
                     # permute rows of matrix P1

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -25,7 +25,7 @@
 
 import numpy as np
 from procrustes.kopt import kopt_heuristic_double, kopt_heuristic_single
-from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays, _zero_padding
+from procrustes.utils import _zero_padding, compute_error, ProcrustesResult, setup_input_arrays
 import scipy
 from scipy.optimize import linear_sum_assignment
 

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -396,8 +396,8 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
                                          guess, tol, iteration)
             # k-opt heuristic
             if kopt:
-                array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
-                                                       p=array_u, k=kopt_k)
+                fun_error = lambda p: compute_error(new_a_positive, new_b_positive, p, p.T)
+                array_u, error = kopt_heuristic_single(fun_error, p0=array_u, k=kopt_k)
             else:
                 error = compute_error(new_a_positive, new_b_positive, array_u, array_u.T)
         # algorithm for directed graph matching problem
@@ -409,8 +409,8 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
                                                   guess, tol, iteration)
             # k-opt heuristic
             if kopt:
-                array_u, error = kopt_heuristic_single(a=new_a_positive, b=new_b_positive,
-                                                       p=array_u, k=kopt_k)
+                fun_error = lambda p: compute_error(new_a_positive, new_b_positive, p, p.T)
+                array_u, error = kopt_heuristic_single(fun_error, p0=array_u, k=kopt_k)
             else:
                 error = compute_error(new_a_positive, new_b_positive, array_u, array_u.T)
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u, s=None)

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -422,8 +422,9 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
         array_p, array_q, error = _2sided_regular(array_m, array_n, tol, iteration)
         # perform k-opt heuristic search twice
         if kopt:
-            array_p, array_q, error = kopt_heuristic_double(a=array_m, b=array_n, p1=array_p,
-                                                            p2=array_q, k=kopt_k)
+            fun_error = lambda p1, p2: compute_error(array_m, array_n, p2, p1.T)
+            array_p, array_q, error = kopt_heuristic_double(fun_error, p1=array_p, p2=array_q,
+                                                            k=kopt_k)
         # return array_m, array_n, array_p, array_q, error
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_q, s=array_p)
     else:

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -295,7 +295,8 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
     array_m = permutation(np.eye(array_m.shape[0]), array_m)["t"]
     # k-opt heuristic
     if kopt:
-        array_m, error = kopt_heuristic_single(a=new_a, b=new_b, p=array_m, k=kopt_k)
+        fun_error = lambda p: compute_error(new_a, new_b, p, p.T)
+        array_m, error = kopt_heuristic_single(fun_error, p0=array_m, k=kopt_k)
     else:
         error = compute_error(new_a, new_b, array_m, array_m.T)
     return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_m, s=None)

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -26,10 +26,11 @@ import numpy as np
 from numpy.testing import assert_equal, assert_raises
 from procrustes.kopt import kopt_heuristic_double, kopt_heuristic_single
 from procrustes.utils import compute_error
+import pytest
 
 
 def test_kopt_heuristic_single_raises():
-    r"""Test k-opt heuristic search algorithm raises."""
+    r"""Test k-opt heuristic single search algorithm raises."""
     # check raises for k
     assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(2), 1)
     assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(3), -2)
@@ -42,36 +43,56 @@ def test_kopt_heuristic_single_raises():
     assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(6) + 0.1, 2)
 
 
-def test_kopt_heuristic_single():
-    r"""Test k-opt heuristic search algorithm."""
-    arr_a = np.array([[3, 6, 1, 0, 7],
-                      [4, 5, 2, 7, 6],
-                      [8, 6, 6, 1, 7],
-                      [4, 4, 7, 9, 4],
-                      [4, 8, 0, 3, 1]])
-    arr_b = np.array([[1, 8, 0, 4, 3],
-                      [6, 5, 2, 4, 7],
-                      [7, 6, 6, 8, 1],
-                      [7, 6, 1, 3, 0],
-                      [4, 4, 7, 4, 9]])
-    perm_guess = np.array([[0, 0, 1, 0, 0],
-                           [1, 0, 0, 0, 0],
-                           [0, 0, 0, 1, 0],
-                           [0, 0, 0, 0, 1],
-                           [0, 1, 0, 0, 0]])
-    perm_exact = np.array([[0, 0, 0, 1, 0],
-                           [0, 1, 0, 0, 0],
-                           [0, 0, 1, 0, 0],
-                           [0, 0, 0, 0, 1],
-                           [1, 0, 0, 0, 0]])
+@pytest.mark.parametrize("m", np.random.randint(5, 10, 2))
+def test_kopt_heuristic_single_identity(m):
+    r"""Test k-opt heuristic single search algorithm with identity permutation."""
+    # create a random matrix A and random permutation of identity matrix
+    a = np.random.uniform(-2.0, 2.0, (m, m))
+    p0 = np.eye(m)
+    # find and check permutation for when B=A with guess p0=I
+    perm, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p0, 2)
+    assert_equal(perm, np.eye(m))
+    assert_equal(error, 0.0)
+    # find and check permutation for when B=A with guess p0 being swapped I
+    p0[[m - 2, -1]] = p0[[-1, m - 2]]
+    perm, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p0, 2)
+    assert_equal(perm, np.eye(m))
+    assert_equal(error, 0.0)
 
-    perm, error = kopt_heuristic_single(lambda p: compute_error(arr_a, arr_b, p, p.T), perm_guess)
-    assert_equal(perm, perm_exact)
-    assert error == 0
+
+@pytest.mark.parametrize("m", np.random.randint(5, 15, 2))
+def test_kopt_heuristic_single_k_permutations(m):
+    r"""Test k-opt heuristic single search algorithm going upto k permutations."""
+    # create a random matrix A
+    a = np.random.uniform(-10.0, 10.0, (m, m))
+    # create permutation matrix by swapping rows m-3 & -1 of identity matrix (this makes sures that
+    # heuristic algorithm only finds the solution towards the end of its search)
+    p = np.eye(m)
+    p[[m - 3, -1]] = p[[-1, m - 3]]
+    # compute B = P^T A P
+    b = np.linalg.multi_dot([p.T, a, p])
+    # find and check permutation
+    perm, error = kopt_heuristic_single(lambda x: compute_error(a, b, x, x.T), np.eye(m), k=2)
+    assert_equal(perm, p)
+    assert_equal(error, 0.0)
+
+
+@pytest.mark.parametrize("m", np.random.randint(2, 15, 3))
+def test_kopt_heuristic_single_all_permutations(m):
+    r"""Test k-opt heuristic single search algorithm going through all permutations."""
+    # create a random matrix A and random permutation of identity matrix
+    a = np.random.uniform(-10.0, 10.0, (m, m))
+    p = np.random.permutation(np.eye(m))
+    # compute B = P^T A P
+    b = np.linalg.multi_dot([p.T, a, p])
+    # find and check permutation
+    perm, error = kopt_heuristic_single(lambda x: compute_error(a, b, x, x.T), np.eye(m), m)
+    assert_equal(perm, p)
+    assert_equal(error, 0.0)
 
 
 def test_kopt_heuristic_double_raises():
-    r"""Test k-opt heuristic search algorithm double raises."""
+    r"""Test k-opt heuristic double search algorithm raises."""
     fun = lambda p: np.sum(p)
     # check raises for k
     assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(2), np.eye(2), 1)
@@ -90,30 +111,59 @@ def test_kopt_heuristic_double_raises():
     assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(5), np.eye(6) + 0.1, 3)
 
 
-def test_kopt_heuristic_double():
-    r"""Test double sided k-opt heuristic search algorithm."""
-    np.random.seed(998)
-    arr_b = np.random.randint(low=-10, high=10, size=(4, 3)).astype(np.float)
-    perm1 = np.array([[0., 0., 0., 1.],
-                      [0., 1., 0., 0.],
-                      [1., 0., 0., 0.],
-                      [0., 0., 1., 0.]])
-    perm2 = np.array([[0., 0., 1.],
-                      [1., 0., 0.],
-                      [0., 1., 0.]])
-    arr_a = np.linalg.multi_dot([perm1.T, arr_b, perm2])
-    # shuffle the permutation matrices
-    perm1_shuff = np.array([[0., 0., 0., 1.],
-                            [1., 0., 0., 0.],
-                            [0., 1., 0., 0.],
-                            [0., 0., 1., 0.]])
-    perm2_shuff = np.array([[1., 0., 0.],
-                            [0., 0., 1.],
-                            [0., 1., 0.]])
-    error = compute_error(arr_b, arr_a, perm2_shuff, perm1_shuff.T)
-    fun_error = lambda p1, p2: compute_error(arr_b, arr_a, p2, p1.T)
-    perm_left, perm_right, kopt_error = kopt_heuristic_double(fun_error, p1=perm1_shuff,
-                                                              p2=perm2_shuff, k=3)
-    _, _, kopt_error = kopt_heuristic_double(fun_error, p1=perm_left, p2=perm_right, k=3)
-    assert kopt_error <= error
-    assert kopt_error == 0
+@pytest.mark.parametrize("m, n", np.random.randint(5, 7, (2, 2)))
+def test_kopt_heuristic_double_identity(m, n):
+    r"""Test k-opt heuristic double search algorithm with identity permutation."""
+    # create a random matrix A and random permutation of identity matrix
+    a = np.random.uniform(-6.0, 6.0, (m, n))
+    p1, p2 = np.eye(m), np.eye(n)
+    # find and check permutation for when B=A with guesses p1=I & p2=I
+    perm1, perm2, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p1, p2, 2)
+    assert_equal(perm1, p1)
+    assert_equal(perm2, p2)
+    assert_equal(error, 0.0)
+    # find and check permutation for when B=A with guesses p1 being swapped I & p2=I
+    p1[[m - 4, -1]] = p1[[-1, m - 4]]
+    perm, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p1, p2, 2)
+    assert_equal(perm1, p1)
+    assert_equal(perm2, p2)
+    assert_equal(error, 0.0)
+
+
+@pytest.mark.parametrize("m, n", np.random.randint(5, 10, (2, 2)))
+def test_kopt_heuristic_double_k_permutations(m, n):
+    r"""Test k-opt heuristic double search algorithm going upto k permutations."""
+    # create a random matrix A
+    a = np.random.uniform(-7.0, 7.0, (m, n))
+    # create permutation matrix by swapping rows m-3 & -1 of identity matrix (this makes sures that
+    # heuristic algorithm only finds the solution towards the end of its search)
+    p1 = np.eye(m)
+    p1[[m - 2, -1]] = p1[[-1, m - 2]]
+    p2 = np.eye(n)
+    p2[[n - 1, -1]] = p2[[-1, n - 1]]
+    # compute B = P^T A P
+    b = np.linalg.multi_dot([p1.T, a, p2])
+    # find and check permutation
+    perm1, perm2, error = kopt_heuristic_double(lambda x: compute_error(a, b, x, x.T),
+                                                np.eye(m), np.eye(n), k=2)
+    assert_equal(perm1, p1)
+    assert_equal(perm2, p2)
+    assert_equal(error, 0.0)
+
+
+@pytest.mark.parametrize("m, n", np.random.randint(2, 7, (3, 2)))
+def test_kopt_heuristic_double_all_permutations(m, n):
+    r"""Test k-opt heuristic double search algorithm going through all permutations."""
+    # create a random matrix A and random permutation of identity matrix
+    print("m, n  = ", m, n)
+    a = np.random.uniform(-5.0, 5.0, (m, n))
+    p1 = np.random.permutation(np.eye(m))
+    p2 = np.random.permutation(np.eye(n))
+    # compute B = P1^T A P2
+    b = np.linalg.multi_dot([p1.T, a, p2])
+    # find and check permutations
+    perm1, perm2, error = kopt_heuristic_double(lambda x, y: compute_error(a, b, y, x.T),
+                                                np.eye(m), np.eye(n), max(n, m))
+    assert_equal(perm1, p1)
+    assert_equal(perm2, p2)
+    assert_equal(error, 0.0)

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -43,19 +43,19 @@ def test_kopt_heuristic_single_raises():
     assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(6) + 0.1, 2)
 
 
-@pytest.mark.parametrize("m", np.random.randint(5, 10, 2))
+@pytest.mark.parametrize("m", np.random.randint(5, 15, 2))
 def test_kopt_heuristic_single_identity(m):
     r"""Test k-opt heuristic single search algorithm with identity permutation."""
     # create a random matrix A and random permutation of identity matrix
     a = np.random.uniform(-2.0, 2.0, (m, m))
     p0 = np.eye(m)
     # find and check permutation for when B=A with guess p0=I
-    perm, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p0, 2)
+    perm, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p0, k=2)
     assert_equal(perm, np.eye(m))
     assert_equal(error, 0.0)
     # find and check permutation for when B=A with guess p0 being swapped I
     p0[[m - 2, -1]] = p0[[-1, m - 2]]
-    perm, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p0, 2)
+    perm, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p0, k=2)
     assert_equal(perm, np.eye(m))
     assert_equal(error, 0.0)
 
@@ -77,7 +77,7 @@ def test_kopt_heuristic_single_k_permutations(m):
     assert_equal(error, 0.0)
 
 
-@pytest.mark.parametrize("m", np.random.randint(2, 15, 3))
+@pytest.mark.parametrize("m", np.random.randint(2, 10, 3))
 def test_kopt_heuristic_single_all_permutations(m):
     r"""Test k-opt heuristic single search algorithm going through all permutations."""
     # create a random matrix A and random permutation of identity matrix
@@ -118,15 +118,16 @@ def test_kopt_heuristic_double_identity(m, n):
     a = np.random.uniform(-6.0, 6.0, (m, n))
     p1, p2 = np.eye(m), np.eye(n)
     # find and check permutation for when B=A with guesses p1=I & p2=I
-    perm1, perm2, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p1, p2, 2)
+    perm1, perm2, error = kopt_heuristic_double(lambda x, y: compute_error(a, a, y, x.T), p1, p2, 2)
     assert_equal(perm1, p1)
     assert_equal(perm2, p2)
     assert_equal(error, 0.0)
-    # find and check permutation for when B=A with guesses p1 being swapped I & p2=I
+    # find and check permutation for when B=A with guesses p1 & p2 being swapped I
     p1[[m - 4, -1]] = p1[[-1, m - 4]]
-    perm, error = kopt_heuristic_single(lambda x: compute_error(a, a, x, x.T), p1, p2, 2)
-    assert_equal(perm1, p1)
-    assert_equal(perm2, p2)
+    p2[[0, -1]] = p2[[-1, 0]]
+    perm1, perm2, error = kopt_heuristic_double(lambda x, y: compute_error(a, a, y, x.T), p1, p2, 2)
+    assert_equal(perm1, np.eye(m))
+    assert_equal(perm2, np.eye(n))
     assert_equal(error, 0.0)
 
 
@@ -144,7 +145,7 @@ def test_kopt_heuristic_double_k_permutations(m, n):
     # compute B = P^T A P
     b = np.linalg.multi_dot([p1.T, a, p2])
     # find and check permutation
-    perm1, perm2, error = kopt_heuristic_double(lambda x: compute_error(a, b, x, x.T),
+    perm1, perm2, error = kopt_heuristic_double(lambda x, y: compute_error(a, b, y, x.T),
                                                 np.eye(m), np.eye(n), k=2)
     assert_equal(perm1, p1)
     assert_equal(perm2, p2)
@@ -155,7 +156,6 @@ def test_kopt_heuristic_double_k_permutations(m, n):
 def test_kopt_heuristic_double_all_permutations(m, n):
     r"""Test k-opt heuristic double search algorithm going through all permutations."""
     # create a random matrix A and random permutation of identity matrix
-    print("m, n  = ", m, n)
     a = np.random.uniform(-5.0, 5.0, (m, n))
     p1 = np.random.permutation(np.eye(m))
     p2 = np.random.permutation(np.eye(n))

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -28,6 +28,20 @@ from procrustes.kopt import kopt_heuristic_double, kopt_heuristic_single
 from procrustes.utils import compute_error
 
 
+def test_kopt_heuristic_single_raises():
+    r"""Test k-opt heuristic search algorithm raises."""
+    # check raises for k
+    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(2), 1)
+    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(3), -2)
+    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(5), 6)
+    # check raises for p0
+    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.ones(3), 2)
+    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.ones((2, 3)), 2)
+    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.ones((4, 4)), 2)
+    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.zeros((5, 5)), 2)
+    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(6) + 0.1, 2)
+
+
 def test_kopt_heuristic_single():
     r"""Test k-opt heuristic search algorithm."""
     arr_a = np.array([[3, 6, 1, 0, 7],
@@ -54,8 +68,6 @@ def test_kopt_heuristic_single():
     perm, error = kopt_heuristic_single(lambda p: compute_error(arr_a, arr_b, p, p.T), perm_guess)
     assert_equal(perm, perm_exact)
     assert error == 0
-    # test the error exceptions
-    assert_raises(ValueError, kopt_heuristic_single, compute_error, perm_guess, 1)
 
 
 def test_kopt_heuristic_double():

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -70,6 +70,26 @@ def test_kopt_heuristic_single():
     assert error == 0
 
 
+def test_kopt_heuristic_double_raises():
+    r"""Test k-opt heuristic search algorithm double raises."""
+    fun = lambda p: np.sum(p)
+    # check raises for k
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(2), np.eye(2), 1)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(3), np.eye(2), -2.5)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(5), np.eye(2), 6)
+    # check raises for p0
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.ones(4), np.eye(3), 2)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(3), np.ones(4), 2)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.ones((2, 3)), np.eye(2), 2)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(2), np.ones((2, 3)), 2)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.ones((4, 4)), np.eye(4), 3)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(4), np.ones((4, 4)), 3)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.zeros((5, 5)), np.eye(6), 4)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(6), np.zeros((5, 5)), 4)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(6) + 0.1, np.eye(5), 3)
+    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(5), np.eye(6) + 0.1, 3)
+
+
 def test_kopt_heuristic_double():
     r"""Test double sided k-opt heuristic search algorithm."""
     np.random.seed(998)

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -50,11 +50,12 @@ def test_kopt_heuristic_single():
                            [0, 0, 1, 0, 0],
                            [0, 0, 0, 0, 1],
                            [1, 0, 0, 0, 0]])
-    perm, kopt_error = kopt_heuristic_single(arr_a, arr_b, perm_guess, 3)
+
+    perm, error = kopt_heuristic_single(lambda p: compute_error(arr_a, arr_b, p, p.T), perm_guess)
     assert_equal(perm, perm_exact)
-    assert kopt_error == 0
+    assert error == 0
     # test the error exceptions
-    assert_raises(ValueError, kopt_heuristic_single, arr_a, arr_b, perm_guess, 1)
+    assert_raises(ValueError, kopt_heuristic_single, compute_error, perm_guess, 1)
 
 
 def test_kopt_heuristic_double():

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -32,15 +32,15 @@ import pytest
 def test_kopt_heuristic_single_raises():
     r"""Test k-opt heuristic single search algorithm raises."""
     # check raises for k
-    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(2), 1)
-    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(3), -2)
-    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(5), 6)
+    assert_raises(ValueError, kopt_heuristic_single, np.sum, np.eye(2), 1)
+    assert_raises(ValueError, kopt_heuristic_single, np.sum, np.eye(3), -2)
+    assert_raises(ValueError, kopt_heuristic_single, np.sum, np.eye(5), 6)
     # check raises for p0
-    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.ones(3), 2)
-    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.ones((2, 3)), 2)
-    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.ones((4, 4)), 2)
-    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.zeros((5, 5)), 2)
-    assert_raises(ValueError, kopt_heuristic_single, lambda p: np.sum(p), np.eye(6) + 0.1, 2)
+    assert_raises(ValueError, kopt_heuristic_single, np.sum, np.ones(3), 2)
+    assert_raises(ValueError, kopt_heuristic_single, np.sum, np.ones((2, 3)), 2)
+    assert_raises(ValueError, kopt_heuristic_single, np.sum, np.ones((4, 4)), 2)
+    assert_raises(ValueError, kopt_heuristic_single, np.sum, np.zeros((5, 5)), 2)
+    assert_raises(ValueError, kopt_heuristic_single, np.sum, np.eye(6) + 0.1, 2)
 
 
 @pytest.mark.parametrize("m", np.random.randint(5, 15, 2))
@@ -93,22 +93,21 @@ def test_kopt_heuristic_single_all_permutations(m):
 
 def test_kopt_heuristic_double_raises():
     r"""Test k-opt heuristic double search algorithm raises."""
-    fun = lambda p: np.sum(p)
     # check raises for k
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(2), np.eye(2), 1)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(3), np.eye(2), -2.5)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(5), np.eye(2), 6)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.eye(2), np.eye(2), 1)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.eye(3), np.eye(2), -2.5)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.eye(5), np.eye(2), 6)
     # check raises for p0
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.ones(4), np.eye(3), 2)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(3), np.ones(4), 2)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.ones((2, 3)), np.eye(2), 2)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(2), np.ones((2, 3)), 2)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.ones((4, 4)), np.eye(4), 3)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(4), np.ones((4, 4)), 3)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.zeros((5, 5)), np.eye(6), 4)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(6), np.zeros((5, 5)), 4)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(6) + 0.1, np.eye(5), 3)
-    assert_raises(ValueError, kopt_heuristic_double, fun, np.eye(5), np.eye(6) + 0.1, 3)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.ones(4), np.eye(3), 2)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.eye(3), np.ones(4), 2)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.ones((2, 3)), np.eye(2), 2)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.eye(2), np.ones((2, 3)), 2)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.ones((4, 4)), np.eye(4), 3)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.eye(4), np.ones((4, 4)), 3)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.zeros((5, 5)), np.eye(6), 4)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.eye(6), np.zeros((5, 5)), 4)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.eye(6) + 0.1, np.eye(5), 3)
+    assert_raises(ValueError, kopt_heuristic_double, np.sum, np.eye(5), np.eye(6) + 0.1, 3)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(5, 7, (2, 2)))

--- a/procrustes/test/test_kopt.py
+++ b/procrustes/test/test_kopt.py
@@ -91,8 +91,9 @@ def test_kopt_heuristic_double():
                             [0., 0., 1.],
                             [0., 1., 0.]])
     error = compute_error(arr_b, arr_a, perm2_shuff, perm1_shuff.T)
-    perm_left, perm_right, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p1=perm1_shuff,
-                                                              p2=perm2_shuff, k=4)
-    _, _, kopt_error = kopt_heuristic_double(a=arr_a, b=arr_b, p1=perm_left, p2=perm_right, k=3)
+    fun_error = lambda p1, p2: compute_error(arr_b, arr_a, p2, p1.T)
+    perm_left, perm_right, kopt_error = kopt_heuristic_double(fun_error, p1=perm1_shuff,
+                                                              p2=perm2_shuff, k=3)
+    _, _, kopt_error = kopt_heuristic_double(fun_error, p1=perm_left, p2=perm_right, k=3)
     assert kopt_error <= error
     assert kopt_error == 0

--- a/tox.ini
+++ b/tox.ini
@@ -154,6 +154,8 @@ ignore =
     D202,
     # E203: Whitespace before ':'
     E203,
+    # E731: Do not assign a lambda expression, use a def
+    E731,
 
 # doc8 configuration
 [doc8]


### PR DESCRIPTION
The commits are self-explanatory, but to summarize:

The `kopt_heuristic_single` and `kopt_heuristic_double` functions were specifically coded for 2-sided permutation Procrustes with 1- or 2-transformations, respectively, which defeats the purpose of having an independent module (I remember that the goal was being able to apply `kopt` to different problems). Also, the `permutation_2sided_explicit` function had its own kopt-style implementation (going through all permutations), so it was repeated-code and redundant. In this regard:

1. `kopt_heuristic_single` and `kopt_heuristic_double` functions are generalized to take an objective function as an argument
2. There were only two tests for kopt functions, so the tests are extended using random matrices, and two bugs are fixed
3. The `permutation_2sided_explicit` function now uses `kopt_heuristic_single`.

There are more changes that need to be made to the `permutation` module, but I didn't want to make this PR any longer so that it's easier to review.