### PR TITLE
Update 1-sided permutation docstring & args name

### DIFF
--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -26,7 +26,7 @@ import itertools as it
 
 import numpy as np
 from procrustes.kopt import kopt_heuristic_double, kopt_heuristic_single
-from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays, _zero_padding
+from procrustes.utils import _zero_padding, compute_error, ProcrustesResult, setup_input_arrays
 import scipy
 from scipy.optimize import linear_sum_assignment
 

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -60,7 +60,7 @@ def test_permutation_columns_pad():
     array_a = np.concatenate((array_a, np.array([[0], [0], [0], [0]])), axis=1)
     array_b = np.concatenate((array_b, np.array([[0, 0, 0, 0]])), axis=0)
     # procrustes with no translate and scale
-    res = permutation(array_a, array_b, remove_zero_col=True, remove_zero_row=True)
+    res = permutation(array_a, array_b, unpad_col=True, unpad_row=True)
     assert_almost_equal(res["new_a"], array_a[:, :-1], decimal=6)
     assert_almost_equal(res["new_b"], array_b[:-1, :], decimal=6)
     assert_almost_equal(res["t"], perm, decimal=6)


### PR DESCRIPTION
- Update the docstring to have the Procrustes formulas at the top
- Change the argument names `remove_zero_col` and `remove_zero_row` to `unpad_col` and `unpad_row`