### PR TITLE
Refactor permutation two sided

### DIFF
--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -141,7 +141,7 @@ def orthogonal(
     if new_a.shape != new_b.shape:
         raise ValueError(
             f"Shape of A and B does not match: {new_a.shape} != {new_b.shape} "
-            "Check pad, remove_zero_col, and remove_zero_row arguments."
+            "Check pad, unpad_col, and unpad_row arguments."
         )
     # calculate SVD of A.T * B
     u, _, vt = scipy.linalg.svd(np.dot(new_a.T, new_b), lapack_driver="gesvd")

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -380,6 +380,9 @@ def permutation_2sided(
     if not (isinstance(kopt, int) or kopt is None):
         raise TypeError(f"kopt parameter {kopt} should be an positive integer or None.")
 
+    if not (isinstance(single, bool)):
+        raise TypeError(f"single parameter {single} should be a Boolean.")
+
     # check inputs
     new_a, new_b = setup_input_arrays(a, b, unpad_col, unpad_row,
                                       pad, translate, scale, check_finite, weight)

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -380,16 +380,17 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
     # check inputs
     new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
                                       pad_mode, translate, scale, check_finite, weight)
-    # np.power() can not handle the negatives values
-    # Try to convert the matrices to non-negative
-    # shift the the matrices to avoid negative values
-    # otherwise it will cause an error in the Eq. 28 in the research notes
-    maximum = max(np.amax(np.abs(new_a)), np.amax(np.abs(new_b)))
-    new_a_positive = new_a.astype(np.float) + maximum
-    new_b_positive = new_b.astype(np.float) + maximum
     # Do single-transformation computation if requested
     transform_mode = transform_mode.lower()
     if transform_mode == "single":
+        # np.power() can not handle the negatives values
+        # Try to convert the matrices to non-negative
+        # shift the the matrices to avoid negative values
+        # otherwise it will cause an error in the Eq. 28 in the research notes
+        maximum = max(np.amax(np.abs(new_a)), np.amax(np.abs(new_b)))
+        new_a_positive = new_a.astype(np.float) + maximum
+        new_b_positive = new_b.astype(np.float) + maximum
+
         # algorithm for undirected graph matching problem
         # check if two matrices are symmetric within a relative tolerance and absolute tolerance.
         if np.allclose(new_a_positive, new_a_positive.T, rtol=1.e-05, atol=1.e-08) and \

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -144,8 +144,8 @@ def permutation(
 
 
 def permutation_2sided(
-        array_a,
-        array_b,
+        a,
+        b,
         transform_mode="single",
         pad=False,
         unpad_col=False,
@@ -165,9 +165,9 @@ def permutation_2sided(
 
     Parameters
     ----------
-    array_a : ndarray
+    a : ndarray
         The 2d-array :math:`\mathbf{A}_{m \times n}` which is going to be transformed.
-    array_b : ndarray
+    b : ndarray
         The 2d-array :math:`\mathbf{B}_{m \times n}` representing the reference.
     transform_mode : str, optional
         When transform_mode="single", it is the two-sided permutation Procrustes with one

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -412,12 +412,6 @@ def permutation_2sided(
             # Compute the permutation matrix by iterations
             array_u = _compute_transform(new_a_positive, new_b_positive,
                                          guess, tol, iteration)
-            # k-opt heuristic
-            if kopt is not None:
-                fun_error = lambda p: compute_error(new_a_positive, new_b_positive, p, p.T)
-                array_u, error = kopt_heuristic_single(fun_error, p0=array_u, k=kopt)
-            else:
-                error = compute_error(new_a_positive, new_b_positive, array_u, array_u.T)
         # algorithm for directed graph matching problem
         else:
             # the initial guess
@@ -425,12 +419,12 @@ def permutation_2sided(
             # Compute the permutation matrix by iterations
             array_u = _compute_transform_directed(new_a_positive, new_b_positive,
                                                   guess, tol, iteration)
-            # k-opt heuristic
-            if kopt is not None:
-                fun_error = lambda p: compute_error(new_a_positive, new_b_positive, p, p.T)
-                array_u, error = kopt_heuristic_single(fun_error, p0=array_u, k=kopt)
-            else:
-                error = compute_error(new_a_positive, new_b_positive, array_u, array_u.T)
+        # k-opt heuristic
+        if kopt is not None:
+            fun_error = lambda p: compute_error(new_a_positive, new_b_positive, p, p.T)
+            array_u, error = kopt_heuristic_single(fun_error, p0=array_u, k=kopt)
+        else:
+            error = compute_error(new_a_positive, new_b_positive, array_u, array_u.T)
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u, s=None)
 
     # Do regular computation with different permutation matrices.

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -393,10 +393,10 @@ def permutation_2sided(
 
     # Do single-transformation computation if requested
     if single:
-        # np.power() can not handle the negatives values
-        # Try to convert the matrices to non-negative
-        # shift the the matrices to avoid negative values
-        # otherwise it will cause an error in the Eq. 28 in the research notes
+        # The update formula for _compute_transform and _compute_transform_directed takes
+        #   the square root of the matrix entries. To avoid taking the square root of negative
+        #   values, the matrices are translated to be positive. This causes no change to the
+        #   objective function, as its a constant value being applied to all entries.
         maximum = max(np.amax(np.abs(new_a)), np.amax(np.abs(new_b)))
         new_a_positive = new_a.astype(np.float) + maximum
         new_b_positive = new_b.astype(np.float) + maximum

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -212,7 +212,7 @@ def permutation_2sided(
         Add small noise if the arrays are non-diagonalizable. Default=False.
     tol : float, optional
         The tolerance value used for updating the initial guess. Default=1.e-8.
-    kopt : int, optional
+    kopt : (int, None) optional
         Perform a k-opt heuristic search afterwards to further optimize/refine the permutation
         matrix by searching over all k-fold permutations of the rows or columns of each permutation
         matrix. For example, kopt_k=3 searches over all permutations of 3 rows or columns.
@@ -377,7 +377,7 @@ def permutation_2sided(
         \end{bmatrix} \\
 
     """
-    if not (isinstance(kopt, int) or kopt is not None):
+    if not (isinstance(kopt, int) or kopt is None):
         raise TypeError(f"kopt parameter {kopt} should be an positive integer or None.")
 
     # check inputs

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -395,8 +395,9 @@ def permutation_2sided(
     if single:
         # The update formula for _compute_transform and _compute_transform_directed takes
         #   the square root of the matrix entries. To avoid taking the square root of negative
-        #   values, the matrices are translated to be positive. This causes no change to the
-        #   objective function, as its a constant value being applied to all entries.
+        #   values and dealing with complex numbers, the matrices are translated to be
+        #   positive. This causes no change to the objective function, as its a constant value
+        #   being applied to all entries.
         maximum = max(np.amax(np.abs(new_a)), np.amax(np.abs(new_b)))
         new_a_positive = new_a.astype(np.float) + maximum
         new_b_positive = new_b.astype(np.float) + maximum

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -425,15 +425,14 @@ def permutation_2sided(
             error = compute_error(new_a_positive, new_b_positive, array_u, array_u.T)
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u, s=None)
     # Do regular computation with different permutation matrices.
-    else:
-        array_p, array_q, error = _2sided_regular(new_a, new_b, tol, iteration)
-        # perform k-opt heuristic search.
-        if kopt is not None:
-            fun_error = lambda p1, p2: compute_error(new_a, new_b, p2, p1.T)
-            array_p, array_q, error = kopt_heuristic_double(fun_error, p1=array_p, p2=array_q,
-                                                            k=kopt)
-        # return array_m, array_n, array_p, array_q, error
-        return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_q, s=array_p)
+    array_p, array_q, error = _2sided_regular(new_a, new_b, tol, iteration)
+    # perform k-opt heuristic search.
+    if kopt is not None:
+        fun_error = lambda p1, p2: compute_error(new_a, new_b, p2, p1.T)
+        array_p, array_q, error = kopt_heuristic_double(fun_error, p1=array_p, p2=array_q,
+                                                        k=kopt)
+    # return array_m, array_n, array_p, array_q, error
+    return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_q, s=array_p)
 
 
 def _2sided_regular(array_m, array_n, tol, iteration):

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -217,6 +217,10 @@ def permutation_2sided(
         matrix by searching over all k-fold permutations of the rows or columns of each permutation
         matrix. For example, kopt_k=3 searches over all permutations of 3 rows or columns.
         If None, then kopt search is not performed. Default=None.
+    weight : ndarray, optional
+        The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
+        elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
+        matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
 
     Returns
     -------

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -379,6 +379,13 @@ def permutation_2sided(
     # check inputs
     new_a, new_b = setup_input_arrays(array_a, array_b, unpad_col, unpad_row,
                                       pad, translate, scale, check_finite, weight)
+    if transform_mode == "single":
+        if new_a.shape != new_b.shape:
+            raise ValueError(
+                f"Shape of A and B does not match: {new_a.shape} != {new_b.shape} "
+                "Check pad, remove_zero_col, and remove_zero_row arguments."
+            )
+
     # Do single-transformation computation if requested
     transform_mode = transform_mode.lower()
     if transform_mode == "single":

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -209,7 +209,7 @@ def permutation_2sided(
         Maximum number for iterations. Default=500.
     tol : float, optional
         The tolerance value used for updating the initial guess. Default=1.e-8.
-    kopt : (int, None) optional
+    kopt : (int, None), optional
         Perform a k-opt heuristic search afterwards to further optimize/refine the permutation
         matrix by searching over all k-fold permutations of the rows or columns of each permutation
         matrix. For example, kopt_k=3 searches over all permutations of 3 rows or columns.

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -143,12 +143,24 @@ def permutation(
     return ProcrustesResult(new_a=new_a, new_b=new_b, t=p, error=error)
 
 
-def permutation_2sided(array_a, array_b, transform_mode="single",
-                       remove_zero_col=True, remove_zero_row=True,
-                       pad_mode="row-col", translate=False, scale=False,
-                       mode="normal1", check_finite=True, iteration=500,
-                       add_noise=False, tol=1.0e-8, kopt=False, kopt_k=3,
-                       weight=None):
+def permutation_2sided(
+        array_a,
+        array_b,
+        transform_mode="single",
+        pad=False,
+        remove_zero_col=True,
+        remove_zero_row=True,
+        translate=False,
+        scale=False,
+        mode="normal1",
+        check_finite=True,
+        iteration=500,
+        add_noise=False,
+        tol=1.0e-8,
+        kopt=False,
+        kopt_k=3,
+        weight=None
+):
     r"""Double sided permutation Procrustes.
 
     Parameters
@@ -170,31 +182,17 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
         Pythagoras Papadimitriou, Ph.D. Thesis, University of Manchester, 1993* is used to solve
         the problem.
         Default="single".
-    Otherwise, transform_mode="double", the
-        two-sided permutation Procrustes with two transformations will be performed.
-        Default="single_undirected".
+        Otherwise, transform_mode="double", the
+            two-sided permutation Procrustes with two transformations will be performed.
+            Default="single_undirected".
+    pad : bool, optional
+        Add zero rows (at the bottom) and/or columns (to the right-hand side) of matrices
+        :math:`\mathbf{A}` and :math:`\mathbf{B}` so that they have the same shape.
     remove_zero_col : bool, optional
         If True, zero columns (values less than 1e-8) on the right side will be removed.
         Default= True.
     remove_zero_row : bool, optional
         If True, zero rows (values less than 1e-8) on the bottom will be removed. Default= True.
-    pad_mode : str, optional
-        Specifying how to pad the arrays, listed below. Default="row-col".
-
-            - "row"
-                The array with fewer rows is padded with zero rows so that both have the same
-                number of rows.
-            - "col"
-                The array with fewer columns is padded with zero columns so that both have the
-                same number of columns.
-            - "row-col"
-                The array with fewer rows is padded with zero rows, and the array with fewer
-                columns is padded with zero columns, so that both have the same dimensions.
-                This does not necessarily result in square arrays.
-            - "square"
-                The arrays are padded with zero rows and zero columns so that they are both
-                squared arrays. The dimension of square array is specified based on the highest
-                dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin, ie columns of the arrays
         will have mean zero.
@@ -379,7 +377,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
     """
     # check inputs
     new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
-                                      pad_mode, translate, scale, check_finite, weight)
+                                      pad, translate, scale, check_finite, weight)
     # Do single-transformation computation if requested
     transform_mode = transform_mode.lower()
     if transform_mode == "single":
@@ -396,8 +394,7 @@ def permutation_2sided(array_a, array_b, transform_mode="single",
         if np.allclose(new_a_positive, new_a_positive.T, rtol=1.e-05, atol=1.e-08) and \
                 np.allclose(new_b_positive, new_b_positive.T, rtol=1.e-05, atol=1.e-08):
             # the initial guess
-            guess = _guess_initial_permutation_undirected(new_a_positive,
-                                                          new_b_positive,
+            guess = _guess_initial_permutation_undirected(new_a_positive, new_b_positive,
                                                           mode, add_noise)
             # Compute the permutation matrix by iterations
             array_u = _compute_transform(new_a_positive, new_b_positive,

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -377,7 +377,7 @@ def permutation_2sided(
     if not (isinstance(kopt, int) or kopt is None):
         raise TypeError(f"kopt parameter {kopt} should be an positive integer or None.")
 
-    if not (isinstance(single, bool)):
+    if not isinstance(single, bool):
         raise TypeError(f"single parameter {single} should be a Boolean.")
 
     # check inputs

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -396,8 +396,8 @@ def permutation_2sided(
         # The update formula for _compute_transform and _compute_transform_directed takes
         #   the square root of the matrix entries. To avoid taking the square root of negative
         #   values and dealing with complex numbers, the matrices are translated to be
-        #   positive. This causes no change to the objective function, as its a constant value
-        #   being applied to all entries.
+        #   positive. This causes no change to the objective function, as it's a constant value
+        #   being added to all entries of a and b.
         maximum = max(np.amax(np.abs(new_a)), np.amax(np.abs(new_b)))
         new_a_positive = new_a.astype(np.float) + maximum
         new_b_positive = new_b.astype(np.float) + maximum
@@ -407,11 +407,9 @@ def permutation_2sided(
         if np.allclose(new_a_positive, new_a_positive.T, rtol=1.e-05, atol=1.e-08) and \
                 np.allclose(new_b_positive, new_b_positive.T, rtol=1.e-05, atol=1.e-08):
             # the initial guess
-            guess = _guess_initial_permutation_undirected(new_a_positive, new_b_positive,
-                                                          mode)
+            guess = _guess_initial_permutation_undirected(new_a_positive, new_b_positive, mode)
             # Compute the permutation matrix by iterations
-            array_u = _compute_transform(new_a_positive, new_b_positive,
-                                         guess, tol, iteration)
+            array_u = _compute_transform(new_a_positive, new_b_positive, guess, tol, iteration)
         # algorithm for directed graph matching problem
         else:
             # the initial guess
@@ -429,7 +427,7 @@ def permutation_2sided(
     # Do regular computation with different permutation matrices.
     else:
         array_p, array_q, error = _2sided_regular(new_a, new_b, tol, iteration)
-        # perform k-opt heuristic search twice
+        # perform k-opt heuristic search.
         if kopt is not None:
             fun_error = lambda p1, p2: compute_error(new_a, new_b, p2, p1.T)
             array_p, array_q, error = kopt_heuristic_double(fun_error, p1=array_p, p2=array_q,

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -426,15 +426,12 @@ def permutation_2sided(
         else:
             error = compute_error(new_a_positive, new_b_positive, array_u, array_u.T)
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=array_u, s=None)
-
     # Do regular computation with different permutation matrices.
     else:
-        array_m = new_a
-        array_n = new_b
-        array_p, array_q, error = _2sided_regular(array_m, array_n, tol, iteration)
+        array_p, array_q, error = _2sided_regular(new_a, new_b, tol, iteration)
         # perform k-opt heuristic search twice
         if kopt is not None:
-            fun_error = lambda p1, p2: compute_error(array_m, array_n, p2, p1.T)
+            fun_error = lambda p1, p2: compute_error(new_a, new_b, p2, p1.T)
             array_p, array_q, error = kopt_heuristic_double(fun_error, p1=array_p, p2=array_q,
                                                             k=kopt)
         # return array_m, array_n, array_p, array_q, error

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -155,7 +155,6 @@ def permutation_2sided(
         mode="normal1",
         check_finite=True,
         iteration=500,
-        add_noise=False,
         tol=1.0e-8,
         kopt=None,
         weight=None
@@ -208,8 +207,6 @@ def permutation_2sided(
         Default=True.
     iteration : int, optional
         Maximum number for iterations. Default=500.
-    add_noise : bool, optional
-        Add small noise if the arrays are non-diagonalizable. Default=False.
     tol : float, optional
         The tolerance value used for updating the initial guess. Default=1.e-8.
     kopt : (int, None) optional
@@ -410,7 +407,7 @@ def permutation_2sided(
                 np.allclose(new_b_positive, new_b_positive.T, rtol=1.e-05, atol=1.e-08):
             # the initial guess
             guess = _guess_initial_permutation_undirected(new_a_positive, new_b_positive,
-                                                          mode, add_noise)
+                                                          mode)
             # Compute the permutation matrix by iterations
             array_u = _compute_transform(new_a_positive, new_b_positive,
                                          guess, tol, iteration)
@@ -603,15 +600,7 @@ def _2sided_1trans_initial_guess_normal2(array_a):
     return array_new
 
 
-def _2sided_1trans_initial_guess_umeyama(array_a, array_b, add_noise):
-    # add small random noise matrix when matrices are not diagonalizable
-    if add_noise:
-        array_a = np.float_(array_a)
-        array_a += np.random.random(array_a.shape) * np.trace(np.abs(array_a)) / \
-            array_a.shape[0] * 1.e-8
-        array_b = np.float_(array_b)
-        array_b += np.random.random(array_b.shape) * np.trace(np.abs(array_b)) / \
-            array_b.shape[0] * 1.e-8
+def _2sided_1trans_initial_guess_umeyama(array_a, array_b):
     # calculate the eigenvalue decomposition of A and B
     _, array_ua = np.linalg.eigh(array_a)
     _, array_ub = np.linalg.eigh(array_b)
@@ -623,9 +612,9 @@ def _2sided_1trans_initial_guess_umeyama(array_a, array_b, add_noise):
     return array_u
 
 
-def _2sided_1trans_initial_guess_umeyama_approx(array_a, array_b, add_noise):
+def _2sided_1trans_initial_guess_umeyama_approx(array_a, array_b):
     # compute U_umeyama
-    array_u = _2sided_1trans_initial_guess_umeyama(array_a, array_b, add_noise)
+    array_u = _2sided_1trans_initial_guess_umeyama(array_a, array_b)
     # calculate the approximated umeyama matrix
     array_ua, _, array_vta = scipy.linalg.svd(array_u, lapack_driver='gesvd')
     u_approx = np.dot(np.abs(array_ua), np.abs(array_vta))
@@ -649,7 +638,7 @@ def _2sided_1trans_initial_guess_directed(array_a, array_b):
     return array_u
 
 
-def _guess_initial_permutation_undirected(array_a, array_b, mode, add_noise):
+def _guess_initial_permutation_undirected(array_a, array_b, mode):
     mode = mode.lower()
     if mode == "normal1":
         tmp_a = _2sided_1trans_initial_guess_normal1(array_a)
@@ -660,9 +649,9 @@ def _guess_initial_permutation_undirected(array_a, array_b, mode, add_noise):
         tmp_b = _2sided_1trans_initial_guess_normal2(array_b)
         array_u = permutation(tmp_a, tmp_b)["t"]
     elif mode == "umeyama":
-        array_u = _2sided_1trans_initial_guess_umeyama(array_a, array_b, add_noise)
+        array_u = _2sided_1trans_initial_guess_umeyama(array_a, array_b)
     elif mode == "umeyama_approx":
-        array_u = _2sided_1trans_initial_guess_umeyama_approx(array_a, array_b, add_noise)
+        array_u = _2sided_1trans_initial_guess_umeyama_approx(array_a, array_b)
     else:
         raise ValueError(
             """

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -148,8 +148,8 @@ def permutation_2sided(
         array_b,
         transform_mode="single",
         pad=False,
-        remove_zero_col=True,
-        remove_zero_row=True,
+        unpad_col=False,
+        unpad_row=False,
         translate=False,
         scale=False,
         mode="normal1",
@@ -188,11 +188,12 @@ def permutation_2sided(
     pad : bool, optional
         Add zero rows (at the bottom) and/or columns (to the right-hand side) of matrices
         :math:`\mathbf{A}` and :math:`\mathbf{B}` so that they have the same shape.
-    remove_zero_col : bool, optional
-        If True, zero columns (values less than 1e-8) on the right side will be removed.
-        Default= True.
-    remove_zero_row : bool, optional
-        If True, zero rows (values less than 1e-8) on the bottom will be removed. Default= True.
+    unpad_col : bool, optional
+        If True, zero columns (with values less than 1.0e-8) on the right-hand side of the intial
+        :math:`\mathbf{A}` and :math:`\mathbf{B}` matrices are removed.
+    unpad_row : bool, optional
+        If True, zero rows (with values less than 1.0e-8) at the bottom of the intial
+        :math:`\mathbf{A}` and :math:`\mathbf{B}` matrices are removed.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin, ie columns of the arrays
         will have mean zero.
@@ -376,7 +377,7 @@ def permutation_2sided(
 
     """
     # check inputs
-    new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+    new_a, new_b = setup_input_arrays(array_a, array_b, unpad_col, unpad_row,
                                       pad, translate, scale, check_finite, weight)
     # Do single-transformation computation if requested
     transform_mode = transform_mode.lower()

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -156,7 +156,7 @@ def rotational(
     if new_a.shape != new_b.shape:
         raise ValueError(
             f"Shape of A and B does not match: {new_a.shape} != {new_b.shape} "
-            "Check pad, remove_zero_col, and remove_zero_row arguments."
+            "Check pad, unpad_col, and unpad_row arguments."
         )
     # compute SVD of A.T * B
     u, _, vt = scipy.linalg.svd(np.dot(new_a.T, new_b), lapack_driver='gesvd')

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -314,7 +314,8 @@ def test_permutation_2sided_4by4_umeyama_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
     res = permutation_2sided(array_a, array_b, transform_mode="single",
-                             translate=True, scale=True, mode="umeyama")
+                             translate=True, scale=True, mode="umeyama",
+                             unpad_col=True, unpad_row=True)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -409,7 +410,8 @@ def test_permutation_2sided_4by4_umeyama_approx_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
     res = permutation_2sided(array_a, array_b, translate=True, scale=True,
-                             transform_mode="single", mode="umeyama_approx")
+                             transform_mode="single", mode="umeyama_approx",
+                             unpad_col=True, unpad_row=True)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -523,7 +525,9 @@ def test_permutation_2sided_4by4_normal1_translate_scale_zero_padding():
     # Check
     res = permutation_2sided(
         array_a, array_b, transform_mode="single",
-        translate=True, scale=True, mode="normal1")
+        translate=True, scale=True, mode="normal1",
+        unpad_col=True, unpad_row=True
+    )
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -659,7 +663,9 @@ def test_permutation_2sided_4by4_normal2_translate_scale_zero_padding():
     # Check
     res = permutation_2sided(
         array_a, array_b, transform_mode="single",
-        translate=True, scale=True, mode="normal2")
+        translate=True, scale=True, mode="normal2",
+        unpad_col=True, unpad_row=True
+    )
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -875,7 +881,10 @@ def test_permutation_2sided_4by4_directed_translate_scale_padding():
     result = permutation_2sided(array_a, array_b,
                                 transform_mode="single",
                                 translate=True,
-                                scale=True)
+                                scale=True,
+                                unpad_col=True,
+                                unpad_row=True
+                                )
     assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
 
@@ -1007,9 +1016,10 @@ def test_permutation_2sided_dominators_zero():
                         [0, 0, 1, 0, 0, 0, 6]])
     res = permutation_2sided(array_a, array_b,
                              transform_mode='single',
-                             remove_zero_col=False,
-                             remove_zero_row=False,
-                             scale=False)
+                             unpad_col=False,
+                             unpad_row=False,
+                             scale=False,
+                             pad=True)
     perm = np.array([[1, 0, 0, 0, 0, 0, 0],
                      [0, 1, 0, 0, 0, 0, 0],
                      [0, 0, 0, 1, 0, 0, 0],

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -204,7 +204,7 @@ def test_2sided_1trans_initial_guess_umeyama():
                           [0.991, 0.524, 0.892, 0.601],
                           [0.520, 0.931, 0.846, 0.618]])
     # U = _2sided_1trans_initial_guess_umeyama(array_a, array_b)
-    array_u = _2sided_1trans_initial_guess_umeyama(array_b, array_a, add_noise=False)
+    array_u = _2sided_1trans_initial_guess_umeyama(array_b, array_a)
     # Check
     assert_almost_equal(u_umeyama, array_u, decimal=3)
 
@@ -973,7 +973,7 @@ def test_permutation_2sided_invalid_transform_mode():
     assert_raises(TypeError, permutation_2sided, array_a, array_b, single="haha")
 
 
-def test_permutation_2sided_add_noise_mode_umeyama():
+def test_permutation_2sided_umeyama():
     r"""Test two sided permutation Procrustes with adding noise mode."""
     array_a = np.array([[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
     # define array_b by permuting array_a
@@ -982,12 +982,12 @@ def test_permutation_2sided_add_noise_mode_umeyama():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # test umeyama method
     result = permutation_2sided(array_a, array_b, translate=False,
-                                scale=False, mode="umeyama", add_noise=True)
+                                scale=False, mode="umeyama")
     assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 
 
-def test_permutation_2sided_add_noise_mode_umeyama_approx():
+def test_permutation_2sided_umeyama_approx():
     r"""Test two sided permutation Procrustes with adding noise mode."""
     array_a = np.array([[4, 5, 3, 3], [5, 7, 3, 5], [3, 3, 2, 2], [3, 5, 2, 5]])
     # define array_b by permuting array_a
@@ -996,7 +996,7 @@ def test_permutation_2sided_add_noise_mode_umeyama_approx():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # test umeyama method
     result = permutation_2sided(array_a, array_b, translate=False, scale=False,
-                                mode="umeyama_approx", add_noise=True)
+                                mode="umeyama_approx")
     assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
 

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -204,7 +204,7 @@ def test_2sided_1trans_initial_guess_umeyama():
                           [0.991, 0.524, 0.892, 0.601],
                           [0.520, 0.931, 0.846, 0.618]])
     # U = _2sided_1trans_initial_guess_umeyama(array_a, array_b)
-    array_u = _2sided_1trans_initial_guess_umeyama(array_b, array_a)
+    array_u = _2sided_1trans_initial_guess_umeyama(array_a=array_b, array_b=array_a)
     # Check
     assert_almost_equal(u_umeyama, array_u, decimal=3)
 

--- a/procrustes/test/test_permutation.py
+++ b/procrustes/test/test_permutation.py
@@ -219,7 +219,7 @@ def test_permutation_2sided_4by4_umeyama():
                      [0., 0., 0., 1.], [0., 1., 0., 0.]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
-    res = permutation_2sided(array_a, array_b, transform_mode="single", mode="umeyama")
+    res = permutation_2sided(array_a, array_b, single=True, mode="umeyama")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -236,7 +236,7 @@ def test_permutation_2sided_4by4_umeyama_loop():
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
-        res = permutation_2sided(array_a, array_b, transform_mode="single", mode="umeyama")
+        res = permutation_2sided(array_a, array_b, single=True, mode="umeyama")
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -253,7 +253,7 @@ def test_permutation_2sided_4by4_umeyama_loop_negative():
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
-        res = permutation_2sided(array_a, array_b, transform_mode="single", mode="umeyama")
+        res = permutation_2sided(array_a, array_b, single=True, mode="umeyama")
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -270,7 +270,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale():
     perm = np.array([[1., 0., 0.], [0., 0., 1.], [0., 1., 0.]])
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + shift), perm))
     # Check
-    res = permutation_2sided(array_a, array_b, transform_mode="single",
+    res = permutation_2sided(array_a, array_b, single=True,
                              translate=True, scale=True, mode="umeyama")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
@@ -289,7 +289,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale_loop():
         # Compute the translated, scaled matrix padded with zeros
         array_b = np.dot(perm.T, np.dot(60 * array_a + 15, perm))
         # Check
-        res = permutation_2sided(array_a, array_b, transform_mode="single",
+        res = permutation_2sided(array_a, array_b, single=True,
                                  translate=True, scale=True, mode="umeyama")
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
@@ -313,7 +313,7 @@ def test_permutation_2sided_4by4_umeyama_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((4, 2))), axis=1)
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
-    res = permutation_2sided(array_a, array_b, transform_mode="single",
+    res = permutation_2sided(array_a, array_b, single=True,
                              translate=True, scale=True, mode="umeyama",
                              unpad_col=True, unpad_row=True)
     assert_almost_equal(res["t"], perm, decimal=6)
@@ -331,7 +331,7 @@ def test_permutation_2sided_4by4_umeyama_approx():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     res = permutation_2sided(array_a, array_b,
-                             transform_mode="single",
+                             single=True,
                              mode="umeyama_approx")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
@@ -350,7 +350,7 @@ def test_permutation_2sided_4by4_umeyama_approx_loop():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         res = permutation_2sided(array_a, array_b,
-                                 transform_mode="single",
+                                 single=True,
                                  mode="umeyama_approx")
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
@@ -369,7 +369,7 @@ def test_permutation_2sided_umeyama_approx_4by4_loop_negative():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         res = permutation_2sided(array_a, array_b,
-                                 transform_mode="single",
+                                 single=True,
                                  mode="umeyama_approx")
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
@@ -387,7 +387,7 @@ def test_permutation_2sided_4by4_umeyama_approx_translate_scale():
     perm = np.array([[1., 0., 0.], [0., 0., 1.], [0., 1., 0.]])
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + shift), perm))
     # Check
-    res = permutation_2sided(array_a, array_b, transform_mode="single",
+    res = permutation_2sided(array_a, array_b, single=True,
                              translate=True, scale=True, mode="umeyama_approx")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
@@ -410,7 +410,7 @@ def test_permutation_2sided_4by4_umeyama_approx_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
     res = permutation_2sided(array_a, array_b, translate=True, scale=True,
-                             transform_mode="single", mode="umeyama_approx",
+                             single=True, mode="umeyama_approx",
                              unpad_col=True, unpad_row=True)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
@@ -425,7 +425,7 @@ def test_permutation_2sided_4by4_normal1():
                      [0., 0., 0., 1.], [0., 1., 0., 0.]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
-    res = permutation_2sided(array_a, array_b, transform_mode="single", mode="normal1")
+    res = permutation_2sided(array_a, array_b, single=True, mode="normal1")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -445,7 +445,7 @@ def test_permutation_2sided_4by4_normal1_loop():
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
             res = permutation_2sided(array_a, array_b,
-                                     transform_mode="single",
+                                     single=True,
                                      mode="normal1",
                                      iteration=700)
             assert_almost_equal(res["t"], perm, decimal=6)
@@ -466,7 +466,7 @@ def test_permutation_2sided_4by4_normal1_loop_negative():
             # Compute the translated, scaled matrix padded with zeros
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
-            res = permutation_2sided(array_a, array_b, transform_mode="single",
+            res = permutation_2sided(array_a, array_b, single=True,
                                      translate=True, scale=True, mode="normal1")
             assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
@@ -482,7 +482,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale():
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + 3.14), perm))
     # Check
     res = permutation_2sided(
-        array_a, array_b, transform_mode="single",
+        array_a, array_b, single=True,
         translate=True, scale=True, mode="normal1")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
@@ -502,7 +502,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale_loop():
         array_b = np.dot(perm.T, np.dot(3 * array_a + 10, perm))
         # Check
         res = permutation_2sided(
-            array_a, array_b, transform_mode="single",
+            array_a, array_b, single=True,
             translate=True, scale=True, mode="normal1")
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
@@ -524,7 +524,7 @@ def test_permutation_2sided_4by4_normal1_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
     res = permutation_2sided(
-        array_a, array_b, transform_mode="single",
+        array_a, array_b, single=True,
         translate=True, scale=True, mode="normal1",
         unpad_col=True, unpad_row=True
     )
@@ -552,7 +552,7 @@ def test_permutation_2sided_normal1_practical_example():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     res = permutation_2sided(
-        array_a, array_b, transform_mode="single",
+        array_a, array_b, single=True,
         translate=True, scale=True, mode="normal1")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
@@ -568,7 +568,7 @@ def test_permutation_2sided_4by4_normal2():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     res = permutation_2sided(
-        array_a, array_b, transform_mode="single", mode="normal2")
+        array_a, array_b, single=True, mode="normal2")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -587,7 +587,7 @@ def test_permutation_2sided_4by4_normal2_loop():
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
             res = permutation_2sided(
-                array_a, array_b, transform_mode="single",
+                array_a, array_b, single=True,
                 translate=True, scale=True, mode="normal2")
             assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
@@ -607,7 +607,7 @@ def test_permutation_2sided_4by4_normal2_loop_negative():
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
             res = permutation_2sided(
-                array_a, array_b, transform_mode="single",
+                array_a, array_b, single=True,
                 translate=True, scale=True, mode="normal2")
             assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
@@ -622,7 +622,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale():
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + 3.14), perm))
     # Check
     res = permutation_2sided(
-        array_a, array_b, transform_mode="single",
+        array_a, array_b, single=True,
         translate=True, scale=True, mode="normal2")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
@@ -641,7 +641,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale_loop():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         res = permutation_2sided(
-            array_a, array_b, transform_mode="single",
+            array_a, array_b, single=True,
             translate=True, scale=True, mode="normal2")
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
@@ -662,7 +662,7 @@ def test_permutation_2sided_4by4_normal2_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
     res = permutation_2sided(
-        array_a, array_b, transform_mode="single",
+        array_a, array_b, single=True,
         translate=True, scale=True, mode="normal2",
         unpad_col=True, unpad_row=True
     )
@@ -689,7 +689,7 @@ def test_permutation_2sided_normal2_practical_example():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     res = permutation_2sided(
-        array_a, array_b, transform_mode="single",
+        array_a, array_b, single=True,
         translate=True, scale=True, mode="normal2")
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
@@ -704,7 +704,7 @@ def test_permutation_2sided_invalid_mode_argument():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     assert_raises(ValueError, permutation_2sided, array_a,
-                  array_b, transform_mode="single", mode="nature")
+                  array_b, single=True, mode="nature")
 
 
 def test_permutation_2sided_regular():
@@ -734,7 +734,7 @@ def test_permutation_2sided_regular():
                         [0, 1, 0, 0, 0],
                         [0, 0, 1, 0, 0],
                         [1, 0, 0, 0, 0]])
-    result = permutation_2sided(array_m, array_n, transform_mode="double")
+    result = permutation_2sided(array_m, array_n, single=False)
     assert_almost_equal(result["s"], array_p, decimal=6)
     assert_almost_equal(result["t"], array_q, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
@@ -753,7 +753,7 @@ def test_permutation_2sided_regular2():
                         [0, 0, 0, 1]])
     array_q = array_p.T
     array_m = np.dot(np.dot(array_p, array_n), array_q)
-    result = permutation_2sided(array_m, array_n, transform_mode="double")
+    result = permutation_2sided(array_m, array_n, single=False)
     assert_almost_equal(result["s"], array_p, decimal=6)
     assert_almost_equal(result["t"], array_q, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
@@ -766,7 +766,7 @@ def test_permutation_2sided_regular_unsquared():
                        [1, 0, 0, 0], [0, 0, 0, 1]])
     perm_q = np.array([[0, 1], [1, 0]])
     array_m = np.linalg.multi_dot([perm_p, array_n, perm_q])
-    result = permutation_2sided(array_m, array_n, transform_mode="double", iteration=500)
+    result = permutation_2sided(array_m, array_n, single=False, iteration=500)
     assert_almost_equal(result["s"], perm_p, decimal=6)
     assert_almost_equal(result["t"], perm_q, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
@@ -781,7 +781,7 @@ def test_permutation_2sided_regular_unsquared_negative():
     perm_p = np.random.permutation(np.eye(6, 6))
     perm_q = np.random.permutation(np.eye(4, 4))
     array_m = np.linalg.multi_dot([perm_p, array_n, perm_q])
-    result = permutation_2sided(array_m, array_n, transform_mode="double", iteration=500)
+    result = permutation_2sided(array_m, array_n, single=False, iteration=500)
     assert_almost_equal(result["s"], perm_p, decimal=6)
     assert_almost_equal(result["t"], perm_q, decimal=6)
     assert_almost_equal(result["error"], 0, decimal=6)
@@ -796,7 +796,7 @@ def test_permutation_2sided_4by4_directed():
     # permuted array_b
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Procrustes with no translate and scale
-    result = permutation_2sided(array_a, array_b, transform_mode="single")
+    result = permutation_2sided(array_a, array_b, single=True)
     assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
 
@@ -810,7 +810,7 @@ def test_permutation_2sided_4by4_directed_symmetric():
     # permuted array_b
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Procrustes with no translate and scale
-    result = permutation_2sided(array_a, array_b, transform_mode="single")
+    result = permutation_2sided(array_a, array_b, single=True)
     assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
 
@@ -826,7 +826,7 @@ def test_permutation_2sided_4by4_directed_loop():
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # check
-        result = permutation_2sided(array_a, array_b, transform_mode="single")
+        result = permutation_2sided(array_a, array_b, single=True)
         assert_almost_equal(result["t"], perm, decimal=6)
         assert_almost_equal(result["error"], 0, decimal=6)
 
@@ -842,7 +842,7 @@ def test_permutation_2sided_4by4_directed_netative_loop():
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # check
-        result = permutation_2sided(array_a, array_b, transform_mode="single")
+        result = permutation_2sided(array_a, array_b, single=True)
         assert_almost_equal(result["t"], perm, decimal=6)
         assert_almost_equal(result["error"], 0, decimal=6)
 
@@ -858,7 +858,7 @@ def test_permutation_2sided_4by4_directed_translate_scale():
     array_b = np.dot(perm.T, np.dot(15.3 * array_a + 5.45, perm))
     # Procrustes with no translate and scale
     result = permutation_2sided(array_a, array_b,
-                                transform_mode="single",
+                                single=True,
                                 translate=True, scale=True)
     assert_almost_equal(result["t"], perm, decimal=6)
     assert_almost_equal(result["error"], 0., decimal=6)
@@ -879,7 +879,7 @@ def test_permutation_2sided_4by4_directed_translate_scale_padding():
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Procrustes with no translate and scale
     result = permutation_2sided(array_a, array_b,
-                                transform_mode="single",
+                                single=True,
                                 translate=True,
                                 scale=True,
                                 unpad_col=True,
@@ -970,7 +970,7 @@ def test_permutation_2sided_invalid_transform_mode():
                      [0., 0., 0., 1.], [0., 1., 0., 0.]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # check
-    assert_raises(ValueError, permutation_2sided, array_a, array_b, transform_mode="haha")
+    assert_raises(TypeError, permutation_2sided, array_a, array_b, single="haha")
 
 
 def test_permutation_2sided_add_noise_mode_umeyama():
@@ -1015,7 +1015,7 @@ def test_permutation_2sided_dominators_zero():
                         [0, 0, 1, 0, 0, 6, 0],
                         [0, 0, 1, 0, 0, 0, 6]])
     res = permutation_2sided(array_a, array_b,
-                             transform_mode='single',
+                             single=True,
                              unpad_col=False,
                              unpad_row=False,
                              scale=False,


### PR DESCRIPTION
This pull request is regarding permutation for two-sided, specifically the function permutation_2sided

The variables for unpad_col, unpad_row and pad were updated to match the other functions.
For single transformation, a check was added to make sure that they are square matrices.
Certain part of the code was moved into the if statement.