### PR TITLE
Lapack driver

### DIFF
--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -84,10 +84,11 @@ def generic(
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
     use_svd : bool, optional
-        If true, compute the singular value decomposition (svd) for the Morse-Penrose inverse
-        from SciPy. If false, use the least-squares implementation, which is less-efficient
-        than svd but is more robust.
-        Default is False.
+        If True, the (Moore-Penrose) pseudo-inverse is computed by singular-value decomposition
+        (SVD) including all 'large' singular values (using scipy.linalg.pinv2).
+        If False, the the (Moore-Penrose) pseudo-inverse is computed by least-squares solver
+        (using scipy.linalg.pinv). The least-squares implementation is less efficient, but more robust,
+        than SVD implementation.
 
     Returns
     -------

--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -85,10 +85,10 @@ def generic(
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
     use_svd : bool, optional
         If True, the (Moore-Penrose) pseudo-inverse is computed by singular-value decomposition
-        (SVD) including all 'large' singular values (using scipy.linalg.pinv2).
+        (SVD) including all 'large' singular values (using `scipy.linalg.pinv2`).
         If False, the the (Moore-Penrose) pseudo-inverse is computed by least-squares solver
-        (using scipy.linalg.pinv). The least-squares implementation is less efficient, but more robust,
-        than SVD implementation.
+        (using `scipy.linalg.pinv`). The least-squares implementation is less efficient, but more
+        robust, than the SVD implementation.
 
     Returns
     -------

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -44,6 +44,7 @@ def orthogonal(
     unpad_row=False,
     check_finite=True,
     weight=None,
+    lapack_driver="gesvd"
 ):
     r"""Perform orthogonal Procrustes.
 
@@ -91,6 +92,9 @@ def orthogonal(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
+    lapack_driver : {"gesvd", "gesdd"}, optional
+        Used in the singular value decomposition function from SciPy. Only allowed two options,
+        with "gesvd" being less-efficient than "gesdd" but is more robust. Default is "gesvd".
 
     Returns
     -------
@@ -144,7 +148,7 @@ def orthogonal(
             "Check pad, unpad_col, and unpad_row arguments."
         )
     # calculate SVD of A.T * B
-    u, _, vt = scipy.linalg.svd(np.dot(new_a.T, new_b), lapack_driver="gesvd")
+    u, _, vt = scipy.linalg.svd(np.dot(new_a.T, new_b), lapack_driver=lapack_driver)
     # compute optimal orthogonal transformation
     u_opt = np.dot(u, vt)
     # compute one-sided error
@@ -164,6 +168,7 @@ def orthogonal_2sided(
     unpad_row=False,
     check_finite=True,
     weight=None,
+    lapack_driver="gesvd"
 ):
     r"""Perform two-sided orthogonal Procrustes with one- or two-transformations.
 
@@ -225,6 +230,9 @@ def orthogonal_2sided(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
+    lapack_driver : {"gesvd", "gesdd"}, optional
+        Used in the singular value decomposition function from SciPy. Only allowed two options,
+        with "gesvd" being less-efficient than "gesdd" but is more robust. Default is "gesvd".
 
     Returns
     -------
@@ -346,8 +354,8 @@ def orthogonal_2sided(
         return ProcrustesResult(error=error, new_a=new_a, new_b=new_b, t=u_opt, s=u_opt.T)
 
     # two-sided orthogonal Procrustes with two-transformations
-    ua, _, vta = scipy.linalg.svd(new_a, lapack_driver="gesvd")
-    ub, _, vtb = scipy.linalg.svd(new_b, lapack_driver="gesvd")
+    ua, _, vta = scipy.linalg.svd(new_a, lapack_driver=lapack_driver)
+    ub, _, vtb = scipy.linalg.svd(new_b, lapack_driver=lapack_driver)
     u_opt1 = np.dot(ua, ub.T)
     u_opt2 = np.dot(vta.T, vtb)
     error = compute_error(new_a, new_b, u_opt2, u_opt1.T)

--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -92,9 +92,10 @@ def orthogonal(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
-    lapack_driver : {"gesvd", "gesdd"}, optional
-        Used in the singular value decomposition function from SciPy. Only allowed two options,
-        with "gesvd" being less-efficient than "gesdd" but is more robust. Default is "gesvd".
+    lapack_driver : {'gesvd', 'gesdd'}, optional
+        Whether to use the more efficient divide-and-conquer approach ('gesdd') or the more robust
+        general rectangular approach ('gesvd') to compute the singular-value decomposition with
+        `scipy.linalg.svd`.
 
     Returns
     -------

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -157,7 +157,8 @@ def permutation_2sided(
         iteration=500,
         tol=1.0e-8,
         kopt=None,
-        weight=None
+        weight=None,
+        lapack_driver="gesvd"
 ):
     r"""Double sided permutation Procrustes.
 
@@ -218,6 +219,10 @@ def permutation_2sided(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
+    lapack_driver : {"gesvd", "gesdd"}, optional
+        Used in the singular value decomposition function from SciPy when mode="umeyama_approx".
+        Only allowed two options, with "gesvd" being less-efficient than "gesdd" but is more robust.
+        Default is "gesvd".
 
     Returns
     -------
@@ -407,7 +412,8 @@ def permutation_2sided(
         if np.allclose(new_a_positive, new_a_positive.T, rtol=1.e-05, atol=1.e-08) and \
                 np.allclose(new_b_positive, new_b_positive.T, rtol=1.e-05, atol=1.e-08):
             # the initial guess
-            guess = _guess_initial_permutation_undirected(new_a_positive, new_b_positive, mode)
+            guess = _guess_initial_permutation_undirected(new_a_positive, new_b_positive, mode,
+                                                          lapack_driver)
             # Compute the permutation matrix by iterations
             array_u = _compute_transform(new_a_positive, new_b_positive, guess, tol, iteration)
         # algorithm for directed graph matching problem
@@ -601,11 +607,11 @@ def _2sided_1trans_initial_guess_umeyama(array_a, array_b):
     return array_u
 
 
-def _2sided_1trans_initial_guess_umeyama_approx(array_a, array_b):
+def _2sided_1trans_initial_guess_umeyama_approx(array_a, array_b, lapack_driver):
     # compute U_umeyama
     array_u = _2sided_1trans_initial_guess_umeyama(array_a, array_b)
     # calculate the approximated umeyama matrix
-    array_ua, _, array_vta = scipy.linalg.svd(array_u, lapack_driver='gesvd')
+    array_ua, _, array_vta = scipy.linalg.svd(array_u, lapack_driver=lapack_driver)
     u_approx = np.dot(np.abs(array_ua), np.abs(array_vta))
     # compute closest unitary transformation to U
     # _, _, U, _ = permutation(np.eye(U.shape[0], dtype=U.dtype), U)
@@ -627,7 +633,7 @@ def _2sided_1trans_initial_guess_directed(array_a, array_b):
     return array_u
 
 
-def _guess_initial_permutation_undirected(array_a, array_b, mode):
+def _guess_initial_permutation_undirected(array_a, array_b, mode, lapack_driver):
     mode = mode.lower()
     if mode == "normal1":
         tmp_a = _2sided_1trans_initial_guess_normal1(array_a)
@@ -640,7 +646,7 @@ def _guess_initial_permutation_undirected(array_a, array_b, mode):
     elif mode == "umeyama":
         array_u = _2sided_1trans_initial_guess_umeyama(array_a, array_b)
     elif mode == "umeyama_approx":
-        array_u = _2sided_1trans_initial_guess_umeyama_approx(array_a, array_b)
+        array_u = _2sided_1trans_initial_guess_umeyama_approx(array_a, array_b, lapack_driver)
     else:
         raise ValueError(
             """

--- a/procrustes/permutation.py
+++ b/procrustes/permutation.py
@@ -219,10 +219,10 @@ def permutation_2sided(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
-    lapack_driver : {"gesvd", "gesdd"}, optional
-        Used in the singular value decomposition function from SciPy when mode="umeyama_approx".
-        Only allowed two options, with "gesvd" being less-efficient than "gesdd" but is more robust.
-        Default is "gesvd".
+    lapack_driver : {'gesvd', 'gesdd'}, optional
+        Whether to use the more efficient divide-and-conquer approach ('gesdd') or the more robust
+        general rectangular approach ('gesvd') to compute the singular-value decomposition with
+        `scipy.linalg.svd`.
 
     Returns
     -------

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -37,6 +37,7 @@ def rotational(
     unpad_row=False,
     check_finite=True,
     weight=None,
+    lapack_driver="gesvd"
 ):
     r"""Perform rotational Procrustes.
 
@@ -84,6 +85,9 @@ def rotational(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
+    lapack_driver : {"gesvd", "gesdd"}, optional
+        Used in the singular value decomposition function from SciPy. Only allowed two options,
+        with "gesvd" being less-efficient than "gesdd" but is more robust. Default is "gesvd".
 
     Returns
     -------
@@ -159,7 +163,7 @@ def rotational(
             "Check pad, unpad_col, and unpad_row arguments."
         )
     # compute SVD of A.T * B
-    u, _, vt = scipy.linalg.svd(np.dot(new_a.T, new_b), lapack_driver='gesvd')
+    u, _, vt = scipy.linalg.svd(np.dot(new_a.T, new_b), lapack_driver=lapack_driver)
     # construct S: an identity matrix with the smallest singular value replaced by sgn(|U*V^t|)
     s = np.eye(new_a.shape[1])
     s[-1, -1] = np.sign(np.linalg.det(np.dot(u, vt)))

--- a/procrustes/rotational.py
+++ b/procrustes/rotational.py
@@ -85,9 +85,10 @@ def rotational(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
-    lapack_driver : {"gesvd", "gesdd"}, optional
-        Used in the singular value decomposition function from SciPy. Only allowed two options,
-        with "gesvd" being less-efficient than "gesdd" but is more robust. Default is "gesvd".
+    lapack_driver : {'gesvd', 'gesdd'}, optional
+        Whether to use the more efficient divide-and-conquer approach ('gesdd') or the more robust
+        general rectangular approach ('gesvd') to compute the singular-value decomposition with
+        `scipy.linalg.svd`.
 
     Returns
     -------

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -87,9 +87,10 @@ def symmetric(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
-    lapack_driver : {"gesvd", "gesdd"}, optional
-        Used in the singular value decomposition function from SciPy. Only allowed two options,
-        with "gesvd" being less-efficient than "gesdd" but is more robust. Default is "gesvd".
+    lapack_driver : {'gesvd', 'gesdd'}, optional
+        Whether to use the more efficient divide-and-conquer approach ('gesdd') or the more robust
+        general rectangular approach ('gesvd') to compute the singular-value decomposition with
+        `scipy.linalg.svd`.
 
     Returns
     -------

--- a/procrustes/symmetric.py
+++ b/procrustes/symmetric.py
@@ -38,6 +38,7 @@ def symmetric(
     unpad_row=False,
     check_finite=True,
     weight=None,
+    lapack_driver="gesvd"
 ):
     r"""Perform symmetric Procrustes.
 
@@ -86,6 +87,9 @@ def symmetric(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
+    lapack_driver : {"gesvd", "gesdd"}, optional
+        Used in the singular value decomposition function from SciPy. Only allowed two options,
+        with "gesvd" being less-efficient than "gesdd" but is more robust. Default is "gesvd".
 
     Returns
     -------
@@ -170,7 +174,7 @@ def symmetric(
     #     raise ValueError(f"Shape of B {new_b.shape}=(m, n) needs to satisfy m >= n.")
 
     # compute SVD of A & matrix C
-    u, s, vt = scipy.linalg.svd(new_a, lapack_driver='gesvd')
+    u, s, vt = scipy.linalg.svd(new_a, lapack_driver=lapack_driver)
     c = np.dot(np.dot(u.T, new_b), vt.T)
 
     # compute intermediate matrix Y

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -55,7 +55,7 @@ def test_generic_square_lapack_driver_and_assertion_error(m):
     array_x = np.random.uniform(-2.0, 2.0, (m, m))
     array_b = np.dot(array_a, array_x)
     # compute procrustes transformation
-    res = generic(array_a, array_b, translate=False, scale=False, lapack_driver="gesdd")
+    res = generic(array_a, array_b, translate=False, scale=False, use_svd=True)
     # check error & arrays
     assert_almost_equal(res.error, 0.0, decimal=6)
     assert_almost_equal(res.t, array_x, decimal=6)
@@ -63,7 +63,7 @@ def test_generic_square_lapack_driver_and_assertion_error(m):
     assert_almost_equal(res.new_b, array_b, decimal=6)
 
     # Check assertion error
-    assert_raises(ValueError, generic, array_a, array_b, lapack_driver="not gessdd or gesvd")
+    assert_raises(TypeError, generic, array_a, array_b, use_svd="not bool")
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(2, 100, (25, 2)))

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -23,7 +23,7 @@
 """Test procrustes.generic module."""
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_raises
 from procrustes.generic import generic
 import pytest
 
@@ -41,10 +41,29 @@ def test_generic_square(m):
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=False, scale=False)
     # check error & arrays
-    assert_almost_equal(res["error"], 0.0, decimal=6)
-    assert_almost_equal(res["t"], array_x, decimal=6)
-    assert_almost_equal(res["new_a"], array_a, decimal=6)
-    assert_almost_equal(res["new_b"], array_b, decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=6)
+    assert_almost_equal(res.t, array_x, decimal=6)
+    assert_almost_equal(res.new_a, array_a, decimal=6)
+    assert_almost_equal(res.new_b, array_b, decimal=6)
+
+
+@pytest.mark.parametrize("m", np.random.randint(2, 100, 25))
+def test_generic_square_lapack_driver_and_assertion_error(m):
+    r"""Test generic Procrustes with random and non-default lapack driver with assertion error."""
+    # random input & transformation arrays (size=mxm)
+    array_a = np.random.uniform(-2.0, 2.0, (m, m))
+    array_x = np.random.uniform(-2.0, 2.0, (m, m))
+    array_b = np.dot(array_a, array_x)
+    # compute procrustes transformation
+    res = generic(array_a, array_b, translate=False, scale=False, lapack_driver="gesdd")
+    # check error & arrays
+    assert_almost_equal(res.error, 0.0, decimal=6)
+    assert_almost_equal(res.t, array_x, decimal=6)
+    assert_almost_equal(res.new_a, array_a, decimal=6)
+    assert_almost_equal(res.new_b, array_b, decimal=6)
+
+    # Check assertion error
+    assert_raises(ValueError, generic, array_a, array_b, lapack_driver="not gessdd or gesvd")
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(2, 100, (25, 2)))
@@ -57,12 +76,12 @@ def test_generic_rectangular(m, n):
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=False, scale=False)
     # check error & arrays
-    assert_almost_equal(res["error"], 0.0, decimal=6)
-    assert_almost_equal(res["new_a"], array_a, decimal=6)
-    assert_almost_equal(res["new_b"], array_b, decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=6)
+    assert_almost_equal(res.new_a, array_a, decimal=6)
+    assert_almost_equal(res.new_b, array_b, decimal=6)
     # check transformation array, only if it is unique
     if m >= n:
-        assert_almost_equal(res["t"], array_x, decimal=6)
+        assert_almost_equal(res.t, array_x, decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(100, 300, (5, 2)))
@@ -76,9 +95,9 @@ def test_generic_rectangular_translate(m, n):
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=True, scale=False)
     # check error & arrays
-    assert_almost_equal(res["error"], 0.0, decimal=6)
-    assert_almost_equal(res["new_a"], array_a - np.mean(array_a, axis=0), decimal=6)
-    assert_almost_equal(res["new_b"], array_b - np.mean(array_b, axis=0), decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=6)
+    assert_almost_equal(res.new_a, array_a - np.mean(array_a, axis=0), decimal=6)
+    assert_almost_equal(res.new_b, array_b - np.mean(array_b, axis=0), decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(200, 400, (10, 2)))
@@ -91,14 +110,14 @@ def test_generic_rectangular_scale(m, n):
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=False, scale=True)
     # check error & arrays
-    assert_almost_equal(res["error"], 0.0, decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=6)
     norm_a = np.linalg.norm(array_a)
     norm_b = np.linalg.norm(array_b)
-    assert_almost_equal(res["new_a"], array_a / norm_a, decimal=6)
-    assert_almost_equal(res["new_b"], array_b / norm_b, decimal=6)
+    assert_almost_equal(res.new_a, array_a / norm_a, decimal=6)
+    assert_almost_equal(res.new_b, array_b / norm_b, decimal=6)
     # check transformation array, only if it is unique
     if m >= n:
-        assert_almost_equal(res["t"], array_x * norm_a / norm_b, decimal=6)
+        assert_almost_equal(res.t, array_x * norm_a / norm_b, decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(500, 1000, (5, 2)))
@@ -111,8 +130,8 @@ def test_generic_rectangular_translate_scale(m, n):
     # compute procrustes transformation
     res = generic(array_a, array_b, translate=True, scale=True)
     # check error & arrays
-    assert_almost_equal(res["error"], 0.0, decimal=6)
+    assert_almost_equal(res.error, 0.0, decimal=6)
     centered_a = array_a - np.mean(array_a, axis=0)
     centered_b = array_b - np.mean(array_b, axis=0)
-    assert_almost_equal(res["new_a"], centered_a / np.linalg.norm(centered_a), decimal=6)
-    assert_almost_equal(res["new_b"], centered_b / np.linalg.norm(centered_b), decimal=6)
+    assert_almost_equal(res.new_a, centered_a / np.linalg.norm(centered_a), decimal=6)
+    assert_almost_equal(res.new_b, centered_b / np.linalg.norm(centered_b), decimal=6)

--- a/procrustes/test/test_orthogonal.py
+++ b/procrustes/test/test_orthogonal.py
@@ -68,6 +68,21 @@ def test_procrustes_rotation_square(n):
 
 
 @pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
+def test_procrustes_rotation_square_lapack_driver(n):
+    r"""Test orthogonal Procrustes with squared array with non-default lapack_driver."""
+    # square array
+    array_a = np.random.uniform(-10.0, 10.0, (n, n))
+    # rotation by 90 degree
+    ortho_arr = ortho_group.rvs(n)
+    array_b = array_a.dot(ortho_arr)
+    res = orthogonal(array_a, array_b, lapack_driver="gesdd")
+    assert_almost_equal(res.error, 0., decimal=6)
+    assert_almost_equal(res.t.dot(res.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(res.t, ortho_arr)
+    assert_equal(res.s, None)
+
+
+@pytest.mark.parametrize("n", np.random.randint(50, 100, (25,)))
 def test_procrustes_reflection_square(n):
     r"""Test orthogonal Procrustes with reflected squared array."""
     # square array
@@ -212,6 +227,24 @@ def test_two_sided_orthogonal_rotate_reflect(m, n):
     array_b = np.dot(np.dot(ref, array_a), rot)
     # compute procrustes transformation
     result = orthogonal_2sided(array_a, array_b, single_transform=False)
+    # check transformation array orthogonality
+    assert_almost_equal(np.dot(result.s, result.s.T), np.eye(m), decimal=6)
+    assert_almost_equal(np.dot(result.t, result.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(result.error, 0, decimal=6)
+
+
+@pytest.mark.parametrize("m, n", np.random.randint(50, 100, (25, 2)))
+def test_two_sided_orthogonal_rotate_reflect_lapack_driver(m, n):
+    r"""Test two sided orthogonal with rotation, reflection and non-default lapack driver."""
+    # define an arbitrary array
+    array_a = np.random.uniform(-10.0, 10.0, (m, n))
+    # define rotation and reflection arrays
+    rot = ortho_group.rvs(n)
+    ref = generate_random_reflection_matrix(m)
+    # define array_b by transforming array_a
+    array_b = np.dot(np.dot(ref, array_a), rot)
+    # compute procrustes transformation
+    result = orthogonal_2sided(array_a, array_b, single_transform=False, lapack_driver="gesvd")
     # check transformation array orthogonality
     assert_almost_equal(np.dot(result.s, result.s.T), np.eye(m), decimal=6)
     assert_almost_equal(np.dot(result.t, result.t.T), np.eye(n), decimal=6)

--- a/procrustes/test/test_rotational.py
+++ b/procrustes/test/test_rotational.py
@@ -38,9 +38,23 @@ def test_rotational_orthogonal_identical(m, n):
     # compute Procrustes transformation
     res = rotational(array_a, array_b, translate=False, scale=False)
     # check result is rotation matrix, and error is zero.
-    assert_almost_equal(np.dot(res["t"], res["t"].T), np.eye(n), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(res["t"])), 1.0, decimal=6)
-    assert_almost_equal(res["error"], 0, decimal=6)
+    assert_almost_equal(np.dot(res.t, res.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res.t)), 1.0, decimal=6)
+    assert_almost_equal(res.error, 0, decimal=6)
+
+
+@pytest.mark.parametrize("m, n", np.random.randint(50, 500, (5, 2)))
+def test_rotational_orthogonal_identical_lapack_driver(m, n):
+    r"""Test rotational Procrustes with identical matrices and different lapack driver."""
+    # define an arbitrary array
+    array_a = np.random.uniform(-10.0, 10.0, (m, n))
+    array_b = np.copy(array_a)
+    # compute Procrustes transformation
+    res = rotational(array_a, array_b, translate=False, scale=False, lapack_driver="gesdd")
+    # check result is rotation matrix, and error is zero.
+    assert_almost_equal(np.dot(res.t, res.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res.t)), 1.0, decimal=6)
+    assert_almost_equal(res.error, 0, decimal=6)
 
 
 @pytest.mark.parametrize("m, n, col_npad, row_npad", np.random.randint(100, 500, (5, 4)))
@@ -56,9 +70,9 @@ def test_rotational_orthogonal_rotation_unpadding(m, n, col_npad, row_npad):
     # compute procrustes transformation
     res = rotational(array_a, array_b, unpad_col=True, unpad_row=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(res["t"], res["t"].T), np.eye(n), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(res["t"])), 1.0, decimal=6)
-    assert_almost_equal(res["error"], 0, decimal=6)
+    assert_almost_equal(np.dot(res.t, res.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res.t)), 1.0, decimal=6)
+    assert_almost_equal(res.error, 0, decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(500, 1000, (5, 2)))
@@ -74,9 +88,9 @@ def test_rotational_orthogonal_rotation_translate_scale(m, n):
     # compute procrustes transformation
     res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(res["t"], res["t"].T), np.eye(n), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(res["t"])), 1.0, decimal=6)
-    assert_almost_equal(res["error"], 0, decimal=6)
+    assert_almost_equal(np.dot(res.t, res.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res.t)), 1.0, decimal=6)
+    assert_almost_equal(res.error, 0, decimal=6)
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(500, 1000, (5, 2)))
@@ -91,9 +105,9 @@ def test_rotational_orthogonal_almost_zero_array(m, n):
     # compute procrustes transformation
     res = rotational(array_a, array_b, translate=True, scale=True)
     # check transformation array and error
-    assert_almost_equal(np.dot(res["t"], res["t"].T), np.eye(n), decimal=6)
-    assert_almost_equal(np.abs(np.linalg.det(res["t"])), 1.0, decimal=6)
-    assert_almost_equal(res["error"], 0, decimal=6)
+    assert_almost_equal(np.dot(res.t, res.t.T), np.eye(n), decimal=6)
+    assert_almost_equal(np.abs(np.linalg.det(res.t)), 1.0, decimal=6)
+    assert_almost_equal(res.error, 0, decimal=6)
 
 
 def test_rotational_raises_error_shape_mismatch():

--- a/procrustes/test/test_symmetric.py
+++ b/procrustes/test/test_symmetric.py
@@ -154,3 +154,17 @@ def test_fat_rectangular_matrices_with_square_padding(nrow):
     # check results (solution is not uniqueness)
     assert_almost_equal(np.abs(res.error - desired_func), 0.0, decimal=5)
     assert_equal(res.s, None)
+
+
+@pytest.mark.parametrize("nrow", np.random.randint(2, 15, (3,)))
+def test_fat_rectangular_matrices_with_square_padding_with_lapack_driver(nrow):
+    r"""Test Symmetric Procrustes with random wide matrices and non-default lapack driver."""
+    # generate random rectangular matrices
+    ncol = np.random.randint(nrow + 1, nrow + 10)
+    array_a, array_b = np.random.random((nrow, ncol)), np.random.random((nrow, ncol))
+    # minimize objective function to find transformation matrix
+    _, desired_func = minimize_one_transformation(array_a, array_b, ncol)
+    res = symmetric(array_a, array_b, pad=True, lapack_driver="gesdd")
+    # check results (solution is not uniqueness)
+    assert_almost_equal(np.abs(res.error - desired_func), 0.0, decimal=5)
+    assert_equal(res.s, None)


### PR DESCRIPTION
This pull request is about adding the lapack driver option whenever singular value decomposition is used. See issue #78.

I added it to rotational, orthogonal, symmetric, permutation and generic.  I also added tests to these.
The doc string of  "lapack_driver" for permutation and generic are different from the other modules.

For generic, I instead used NumPy's Morse Penrose inverse if "lapack_driver="gessd""  and SciPy's Morse Penrose inverse if "lapack_driver="gesvd"".
