### PR TITLE
Add conda build conda recipe, meta.yaml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: qc-procrustes
+  name: procrustes
   version: "{{ load_setup_py_data().version }}"
 
 python:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,7 +1,6 @@
 package:
   name: qc-procrustes
-  # version: "{{ load_setup_py_data().version }}"
-  version: "0.0.1"
+  version: "{{ load_setup_py_data().version }}"
 
 python:
   - 3.6
@@ -35,10 +34,10 @@ requirements:
 about:
   summary: "Finding the optimal transformation(s) that makes two matrices as close as possible to each other."
   description: |
-  This package supports general, generic, orthogonal, rotation, permutation, and
-  symmetric Procrustes problems, including both the normal one-sided approach and (for orthogonal
-  and permutation Procrustes) two-sided approaches, where both the rows and columns are transformed.
-  Softassign algorithm is also implemented to solve two-sided permutation Procrustes.
+    This package supports general, generic, orthogonal, rotation, permutation, and
+    symmetric Procrustes problems, including both the normal one-sided approach and (for orthogonal
+    and permutation Procrustes) two-sided approaches, where both the rows and columns are
+    transformed. Softassign algorithm is also implemented to solve two-sided permutation Procrustes.
   home: https://procrustes.readthedocs.io/en/latest/
   doc_url: https://iodata.readthedocs.io/en/latest/
   dev_url: https://github.com/theochem/procrustes/

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,49 @@
+package:
+  name: qc-procrustes
+  version: "0.0.1"
+
+python:
+  - 3.6
+  - 3.7
+  - 3.8
+  - 3.9
+
+source:
+  path: ../
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps"
+
+requirements:
+  build:
+    - python >=3.6
+    - numpy >=1.18.5
+    - scipy >=1.5.0
+    - pytest >=5.4.3
+    - sphinx >=2.3.0
+  run:
+    - python >=3.6
+    - numpy >=1.18.5
+    - scipy >=1.5.0
+    - pytest >=5.4.3
+    - sphinx >=2.3.0
+
+
+about:
+  summary: "Finding the optimal transformation(s) that makes two matrices as close as possible to each other."
+  description: |
+  This package supports general, generic, orthogonal, rotation, permutation, and
+  symmetric Procrustes problems, including both the normal one-sided approach and (for orthogonal
+  and permutation Procrustes) two-sided approaches, where both the rows and columns are transformed.
+  Softassign algorithm is also implemented to solve two-sided permutation Procrustes.
+  home: https://procrustes.readthedocs.io/en/latest/
+  doc_url: https://iodata.readthedocs.io/en/latest/
+  dev_url: https://github.com/theochem/procrustes/
+  license: GNU Version 3
+  license_family: GPL
+  license_file: LICENSE
+
+extra:
+  maintainers: QC-Dev community

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -46,4 +46,4 @@ about:
   license_file: LICENSE
 
 extra:
-  maintainers: QC-Dev community
+  maintainers: QC-Dev community  <qcdevs@gmail.com>

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,6 @@
 package:
   name: qc-procrustes
+  # version: "{{ load_setup_py_data().version }}"
   version: "0.0.1"
 
 python:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def get_readme():
 
 setup(
     name="qc-procrustes",
-    version="0.0.1-alpha",
+    version="0.0.1b1",
     description="Procrustes Package",
     long_description=get_readme(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR mainly adds the `meta.yaml` file for `conda` builds and it has passed a test on Fedora 33.

- [x] Add conda build yaml file
- [x] Fix package version
- [x] Update `procrustes` package version number to `0.0.1b1` (beta release) as we are at a stage to track/fix problems and no new features are going to be implemented for this stage. Moreover, the original version number is not following the conventions, resulting in an error of building conda tarballs.
