### PR TITLE
Fix up documenation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -120,7 +120,7 @@ mathjax_config = {
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = ['.rst', '.ipynb']
+# source_suffix = ['.rst', '.ipynb']
 
 # The master toctree document.
 master_doc = 'index'

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -86,7 +86,7 @@ are also implemented in our package. The GPA algorithm seeks the optimal transfo
 
 .. math::
     \begin{equation}
-      \min \sum_{i<j}^{j} {\left\| \mathbf{A}_i \mathbf{T}_i - \mathbf{A}_j \mathbf{T}_j \right\|}^2
+      \min \sum_{i<j}^{j} {\left\| \mathbf{A}_i \mathbf{T}_i - \mathbf{A}_j \mathbf{T}_j \right\|_F}^2
     \end{equation}
 
 where :math:`\mathbf{A}_i` and :math:`\mathbf{A}_j` are the configurations and :math:`\mathbf{T}_i`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -26,7 +26,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Procrustes's documentation!
+Welcome to Procrustes's Documentation!
 ======================================
 
 `Procrustes <https://github.com/theochem/procrustes>`_ is a free, open-source, and cross-platform
@@ -100,8 +100,8 @@ assignment problem
 developed theoretically
 :cite:`gold1996softassign,rangarajan1997convergence` and extended to many other applications
 :cite:`wang2018application,gold1996softassign,gold1996softmax,tian2012convergence,sheikhbahaee2017photometric`.
-Because the two-sided permutation Procrustes problem is a special
-quadratic assignment problem it can be used here. The objective function is to minimize
+Because the two-sided permutation Procrustes problem is a special case of the
+quadratic assignment problem, it can be used here. The objective function is to minimize
 :math:`E_{qap} (\mathbf{M}, \mu, \nu)`, :cite:`gold1996softassign,yuille1994statistical`,
 which is defined as follows,
 
@@ -119,8 +119,8 @@ which is defined as follows,
 
 Procrustes problems arise when aligning molecules and other objects, when evaluating optimal basis
 transformations, when determining optimal mappings between sets, and in many other contexts. This
-package includes options to translate, scale, and zero-pad matrices, so that matrices with different
-centers/scaling/sizes can be considered.
+package includes the options to translate, scale, and zero-pad matrices, so that matrices with
+different centers/scaling/sizes can be considered.
 
 
 .. toctree::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -128,7 +128,7 @@ different centers/scaling/sizes can be considered.
    :caption: User Documentation
 
    usr_doc_installization
-   notebooks/Quick_Start.ipynb
+   notebooks/Quick_Start
    usr_doc_tutorials
    usr_doc_zref
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,8 +41,8 @@ Please use the following citation in any publication using Procrustes library:
 The Procrustes source code is hosted on `GitHub <https://github.com/theochem/procrustes>`_ and is
 released under the
 `GNU General Public License v3.0 <https://github.com/theochem/procrustes/blob/master/LICENSE>`_.
-We welcome any contributions to the Procrustes library in accord with our Code of Conduct;
-please see our `Contributing Guidelines <link to QCDevs>`_.
+We welcome any contributions to the Procrustes library in accordance with our Code of Conduct;
+please see our `Contributing Guidelines <https://qcdevs.org/guidelines/QCDevsCodeOfConduct/>`_.
 Please report any issues you encounter while using Procrustes library on
 `GitHub Issues <https://github.com/theochem/procrustes/issues>`_.
 For further information and inquiries please contact us at `qcdevs@gmail.com <qcdevs@gmail.com>`_.

--- a/doc/notebooks/Chemical_Structure_Alignment.ipynb
+++ b/doc/notebooks/Chemical_Structure_Alignment.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Molecular alignment is a fundamental problem in cheminformatics and can be used for  structure  determination,  similarity  based  searching,  and ligand-baseddrug design *et al*. This problem can be solved as a orthogonal Procrustes problem when given two matrices representing three-dimensional coordinates.  The code block below shows the ease-of-use of the `Procrustes` library for protein structure alignment, one of themost fundamental problems in structural biophysics."
+    "Molecular alignment is a fundamental problem in cheminformatics and can be used for  structure  determination,  similarity  based  searching,  and ligand-based drug design *et al*. This problem can be solved as a orthogonal Procrustes problem when given two matrices representing three-dimensional coordinates.  The code block below shows the ease-of-use of the `Procrustes` library for protein structure alignment, one of themost fundamental problems in structural biophysics."
    ]
   },
   {

--- a/doc/usr_doc_installization.rst
+++ b/doc/usr_doc_installization.rst
@@ -47,7 +47,7 @@ The following dependencies will be necessary for Procrustes to build properly,
 * SciPy >= 1.5.0: `https://www.scipy.org/ <http://www.scipy.org/>`_
 * NumPy >= 1.18.5: `https://www.numpy.org/ <http://www.numpy.org/>`_
 * Pip >= 19.0: `https://pip.pypa.io/ <https://pip.pypa.io/>`_
-* PyTest >= 5.3.4: `https://docs.pytest.org/ <https://docs.pytest.org/>`_
+* PyTest >= 5.4.3: `https://docs.pytest.org/ <https://docs.pytest.org/>`_
 * PyTest-Cov >= 2.8.0: `https://pypi.org/project/pytest-cov/ <https://pypi.org/project/pytest-cov/>`_
 * Sphinx >= 2.3.0, if one wishes to build the documentation locally:
   `https://www.sphinx-doc.org/ <https://www.sphinx-doc.org/>`_


### PR DESCRIPTION
Following changes are made:
- minor grammar/capitalization/spacing changes
-  Add QCDecs' code of conduct
- Specify Frobenius norm in one of the equation (for consistency)
- Fix nbsphinx behaviour

It'd be great if someone can double-check that the equation for the norm is supposed to be Frobenius (I thought it'd make it consistent with the equation above)

As for nbsphinx, the issue was that the `Quick Start` section was not behaving well (is unavailable in the side panel and is displayed in raw form). I think it depends on which version readthedocs has on their server. I'm pretty sure it's the latest one, but it should be checked once it gets uploaded.