### PR TITLE
Softassign api

### DIFF
--- a/procrustes/orthogonal.py
+++ b/procrustes/orthogonal.py
@@ -338,12 +338,12 @@ def orthogonal_2sided(
         if not np.allclose(new_a.T, new_a):
             raise ValueError(
                 f"Array A with {new_a.shape} shape is not symmetric. "
-                "Check pad, remove_zero_col, and remove_zero_row arguments."
+                "Check pad, unpad_col, and unpad_row arguments."
             )
         if not np.allclose(new_b.T, new_b):
             raise ValueError(
                 f"Array B with {new_b.shape} shape is not symmetric. "
-                "Check pad, remove_zero_col, and remove_zero_row arguments."
+                "Check pad, unpad_col, and unpad_row arguments."
             )
 
     # two-sided orthogonal Procrustes with one-transformations

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -67,9 +67,9 @@ def softassign(
 
     Parameters
     ----------
-    array_a : ndarray
+    a : ndarray
         The 2d-array :math:`\mathbf{A}_{m \times n}` which is going to be transformed.
-    array_b : ndarray
+    b : ndarray
         The 2d-array :math:`\mathbf{B}_{m \times n}` representing the reference.
     iteration_soft ： int, optional
         Number of iterations for softassign loop. Default=50.
@@ -190,9 +190,9 @@ def softassign(
         # define a random matrix
     >>> perm = np.array([[0., 0., 1., 0.], [1., 0., 0., 0.],
     ...                  [0., 0., 0., 1.], [0., 1., 0., 0.]])
-        # define array_b by permuting array_a
-    >>> array_b = np.dot(perm.T, np.dot(array_a, perm))
-    >>> new_a, new_b, M_ai, error = softassign(array_a, array_b,
+        # define b by permuting array_a
+    >>> b = np.dot(perm.T, np.dot(a, perm))
+    >>> new_a, new_b, M_ai, error = softassign(a, b,
     ...                                        unpad_col=False,
     ...                                        unpad_row=False)
     >>> M_ai # the permutation matrix
@@ -211,7 +211,7 @@ def softassign(
     if beta_r <= 1:
         raise ValueError("Argument beta_r cannot be less than 1.")
 
-    new_a, new_b = setup_input_arrays(array_a, array_b, unpad_col, unpad_row,
+    new_a, new_b = setup_input_arrays(a, b, unpad_col, unpad_row,
                                       pad_mode, translate, scale, check_finite, weight)
     # Initialization
     # Compute the benefit matrix

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -38,7 +38,7 @@ __all__ = [
 def softassign(
     a,
     b,
-    pad=False,
+    pad=True,
     translate=False,
     scale=False,
     unpad_col=False,
@@ -195,7 +195,7 @@ def softassign(
     new_a, new_b = setup_input_arrays(a, b, unpad_col, unpad_row,
                                       pad, translate, scale, check_finite, weight)
 
-    # check that A & B are square and that they match each other.
+    # Check that A & B are square and that they match each other.
     if new_a.shape[0] != new_a.shape[1]:
         raise ValueError(f"Matrix A should be square but A.shape={new_a.shape}"
                          "Check pad, unpad_col, and unpad_row arguments.")

--- a/procrustes/softassign.py
+++ b/procrustes/softassign.py
@@ -35,13 +35,33 @@ __all__ = [
 ]
 
 
-def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
-               beta_r=1.10, beta_f=1.e5, epsilon=0.05, epsilon_soft=1.e-3,
-               epsilon_sink=1.e-3, k=0.15, gamma_scaler=1.01, n_stop=3,
-               pad_mode='row-col', remove_zero_col=True, remove_zero_row=True,
-               translate=False, scale=False, check_finite=True, adapted=True,
-               beta_0=None, m_guess=None, iteration_anneal=None, kopt=False,
-               kopt_k=3, weight=None):
+def softassign(
+    a,
+    b,
+    iteration_soft=50,
+    iteration_sink=200,
+    beta_r=1.10,
+    beta_f=1.e5,
+    epsilon=0.05,
+    epsilon_soft=1.e-3,
+    epsilon_sink=1.e-3,
+    k=0.15,
+    gamma_scaler=1.01,
+    n_stop=3,
+    pad_mode='row-col',
+    unpad_col=False,
+    unpad_row=False,
+    translate=False,
+    scale=False,
+    check_finite=True,
+    adapted=True,
+    beta_0=None,
+    m_guess=None,
+    iteration_anneal=None,
+    kopt=False,
+    kopt_k=3,
+    weight=None
+):
     r"""
     Find the transformation matrix for 2-sided permutation Procrustes with softassign algorithm.
 
@@ -95,12 +115,12 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
                 The arrays are padded with zero rows and zero columns so that they are both
                 squared arrays. The dimension of square array is specified based on the highest
                 dimension, i.e. :math:`\text{max}(n_a, m_a, n_b, m_b)`.
-    remove_zero_col : bool, optional
+    unpad_col : bool, optional
         If True, zero columns (values less than 1e-8) on the right side will be removed.
-        Default=True.
-    remove_zero_row : bool, optional
+        Default=False.
+    unpad_row : bool, optional
         If True, zero rows (values less than 1e-8) on the bottom will be removed.
-        Default=True.
+        Default=False.
     translate : bool, optional
         If True, both arrays are translated to be centered at origin, ie columns of the arrays
         will have mean zero.
@@ -173,8 +193,8 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
         # define array_b by permuting array_a
     >>> array_b = np.dot(perm.T, np.dot(array_a, perm))
     >>> new_a, new_b, M_ai, error = softassign(array_a, array_b,
-    ...                                        remove_zero_col=False,
-    ...                                        remove_zero_row=False)
+    ...                                        unpad_col=False,
+    ...                                        unpad_row=False)
     >>> M_ai # the permutation matrix
     array([[0., 0., 1., 0.],
            [1., 0., 0., 0.],
@@ -191,7 +211,7 @@ def softassign(array_a, array_b, iteration_soft=50, iteration_sink=200,
     if beta_r <= 1:
         raise ValueError("Argument beta_r cannot be less than 1.")
 
-    new_a, new_b = setup_input_arrays(array_a, array_b, remove_zero_col, remove_zero_row,
+    new_a, new_b = setup_input_arrays(array_a, array_b, unpad_col, unpad_row,
                                       pad_mode, translate, scale, check_finite, weight)
     # Initialization
     # Compute the benefit matrix

--- a/procrustes/test/test_softassign.py
+++ b/procrustes/test/test_softassign.py
@@ -40,8 +40,8 @@ def test_softassign_4by4():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     res = softassign(array_a, array_b,
-                     remove_zero_col=False,
-                     remove_zero_row=False)
+                     unpad_col=False,
+                     unpad_row=False)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -59,8 +59,8 @@ def test_softassign_4by4_loop():
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
         res = softassign(array_a, array_b,
-                         remove_zero_col=False,
-                         remove_zero_row=False)
+                         unpad_col=False,
+                         unpad_row=False)
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -80,8 +80,8 @@ def test_softassign_4by4_loop_negative():
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
             res = softassign(array_a, array_b,
-                             remove_zero_row=False,
-                             remove_zero_col=False)
+                             unpad_row=False,
+                             unpad_col=False)
             assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -97,8 +97,8 @@ def test_softassign_4by4_translate_scale():
     # Check
     res = softassign(array_a, array_b,
                      translate=True, scale=True,
-                     remove_zero_row=False,
-                     remove_zero_col=False)
+                     unpad_row=False,
+                     unpad_col=False)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -141,8 +141,8 @@ def test_softassign_4by4_translate_scale_zero_padding():
     res = softassign(array_a, array_b,
                      translate=False,
                      scale=False,
-                     remove_zero_row=True,
-                     remove_zero_col=True)
+                     unpad_row=True,
+                     unpad_col=True)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -169,8 +169,8 @@ def test_softassign_practical_example():
     res = softassign(array_a, array_b,
                      translate=False,
                      scale=False,
-                     remove_zero_row=False,
-                     remove_zero_col=False)
+                     unpad_row=False,
+                     unpad_col=False)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -197,8 +197,8 @@ def test_softassign_random_noise():
     res = softassign(array_a, array_b,
                      translate=False,
                      scale=False,
-                     remove_zero_row=False,
-                     remove_zero_col=False)
+                     unpad_row=False,
+                     unpad_col=False)
     assert_almost_equal(res["t"], perm, decimal=6)
 
 
@@ -321,8 +321,8 @@ def test_softassign_kopt():
     res_no_kopt = softassign(array_a, array_b,
                              translate=False,
                              scale=False,
-                             remove_zero_row=False,
-                             remove_zero_col=False,
+                             unpad_row=False,
+                             unpad_col=False,
                              kopt=False,
                              iteration_soft=1,
                              iteration_sink=1,
@@ -338,8 +338,8 @@ def test_softassign_kopt():
     res_with_kopt = softassign(array_a, array_b,
                                translate=False,
                                scale=False,
-                               remove_zero_row=False,
-                               remove_zero_col=False,
+                               unpad_row=False,
+                               unpad_col=False,
                                kopt=True,
                                iteration_soft=1,
                                iteration_sink=1,

--- a/procrustes/test/test_softassign.py
+++ b/procrustes/test/test_softassign.py
@@ -89,7 +89,8 @@ def test_softassign_4by4_translate_scale():
     perm = np.array([[1., 0., 0.], [0., 0., 1.], [0., 1., 0.]])
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + 3.14), perm))
     # Check
-    res = softassign(array_a, array_b, translate=True, scale=True, unpad_col=False, unpad_row=False)
+    res = softassign(array_a, array_b, translate=True, scale=True,
+                     unpad_col=False, unpad_row=False)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -219,11 +220,10 @@ def test_softassign_4by4_beta_0():
                      [0, 0, 1, 0], [0, 0, 0, 1]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
-    res = softassign(array_a,
-                     array_b,
-                     beta_0=1.e-6,
-                     translate=False,
-                     scale=False)
+    res = softassign(array_a, array_b,
+                     translate=False, scale=False,
+                     beta_0=1.e-6, adapted=False,
+                     epsilon_soft=1e-8)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 

--- a/procrustes/test/test_softassign.py
+++ b/procrustes/test/test_softassign.py
@@ -39,9 +39,7 @@ def test_softassign_4by4():
                      [0., 1., 0., 0.]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
-    res = softassign(array_a, array_b,
-                     unpad_col=False,
-                     unpad_row=False)
+    res = softassign(array_a, array_b, unpad_col=False, unpad_row=False)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -58,9 +56,7 @@ def test_softassign_4by4_loop():
         # get array_b by permutation
         array_b = np.dot(perm.T, np.dot(array_a, perm))
         # Check
-        res = softassign(array_a, array_b,
-                         unpad_col=False,
-                         unpad_row=False)
+        res = softassign(array_a, array_b, unpad_col=False, unpad_row=False)
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -79,9 +75,7 @@ def test_softassign_4by4_loop_negative():
             # Compute the translated, scaled matrix padded with zeros
             array_b = np.dot(perm.T, np.dot(array_a, perm))
             # Check
-            res = softassign(array_a, array_b,
-                             unpad_row=False,
-                             unpad_col=False)
+            res = softassign(array_a, array_b, unpad_col=False, unpad_row=False)
             assert_almost_equal(res["t"], perm, decimal=6)
             assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -116,10 +110,7 @@ def test_softassign_4by4_translate_scale_loop():
         # Compute the translated, scaled matrix padded with zeros
         array_b = np.dot(perm.T, np.dot(3 * array_a + 10, perm))
         # Check
-        res = softassign(array_a,
-                         array_b,
-                         translate=True,
-                         scale=True)
+        res = softassign(array_a, array_b, translate=True, scale=True)
         assert_almost_equal(res["t"], perm, decimal=6)
         assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -138,11 +129,7 @@ def test_softassign_4by4_translate_scale_zero_padding():
     array_b = np.concatenate((array_b, np.zeros((4, 2))), axis=1)
     array_b = np.concatenate((array_b, np.zeros((6, 6))), axis=0)
     # Check
-    res = softassign(array_a, array_b,
-                     translate=False,
-                     scale=False,
-                     unpad_row=True,
-                     unpad_col=True)
+    res = softassign(array_a, array_b, translate=False, scale=False, unpad_col=True, unpad_row=True)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -167,10 +154,8 @@ def test_softassign_practical_example():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     res = softassign(array_a, array_b,
-                     translate=False,
-                     scale=False,
-                     unpad_row=False,
-                     unpad_col=False)
+                     translate=False, scale=False,
+                     unpad_col=False, unpad_row=False)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -195,10 +180,8 @@ def test_softassign_random_noise():
     array_b = np.dot(perm.T, np.dot(array_a, perm)) + np.random.randn(5, 5)
     # Check
     res = softassign(array_a, array_b,
-                     translate=False,
-                     scale=False,
-                     unpad_row=False,
-                     unpad_col=False)
+                     translate=False, scale=False,
+                     unpad_col=False, unpad_row=False)
     assert_almost_equal(res["t"], perm, decimal=6)
 
 
@@ -242,11 +225,7 @@ def test_softassign_4by4_anneal_steps():
                      [0, 0, 1, 0], [0, 0, 0, 1]])
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
-    res = softassign(array_a,
-                     array_b,
-                     iteration_anneal=165,
-                     translate=False,
-                     scale=False)
+    res = softassign(array_a, array_b, translate=False, scale=False, iteration_anneal=165)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -280,20 +259,12 @@ def test_softassign_m_guess():
     # check assert raises
     assert_raises(ValueError, softassign, array_a, array_b, m_guess=m_guess1)
     # check if initial guess works
-    res = softassign(array_a,
-                     array_b,
-                     m_guess=m_guess2,
-                     translate=False,
-                     scale=False)
+    res = softassign(array_a, array_b, translate=False, scale=False, m_guess=m_guess2)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
     # check if initial guess given shape not matching
     with warnings.catch_warnings(record=True) as warn_info:
-        res = softassign(array_a,
-                         array_b,
-                         m_guess=m_guess3,
-                         translate=False,
-                         scale=False)
+        res = softassign(array_a, array_b, translate=False, scale=False, m_guess=m_guess3)
         # catch the error information
         assert len(warn_info) == 1
         assert not str(warn_info[0].message).startswith("We must specify")
@@ -321,9 +292,8 @@ def test_softassign_kopt():
     res_no_kopt = softassign(array_a, array_b,
                              translate=False,
                              scale=False,
-                             unpad_row=False,
                              unpad_col=False,
-                             kopt=False,
+                             unpad_row=False,
                              iteration_soft=1,
                              iteration_sink=1,
                              beta_r=1.05,
@@ -333,14 +303,14 @@ def test_softassign_kopt():
                              epsilon_sink=1.e-3,
                              k=0.15,
                              gamma_scaler=1.5,
-                             n_stop=2)
+                             n_stop=2,
+                             kopt=False)
     # softassign with kopt
     res_with_kopt = softassign(array_a, array_b,
                                translate=False,
                                scale=False,
-                               unpad_row=False,
                                unpad_col=False,
-                               kopt=True,
+                               unpad_row=False,
                                iteration_soft=1,
                                iteration_sink=1,
                                beta_r=1.05,
@@ -350,5 +320,6 @@ def test_softassign_kopt():
                                epsilon_sink=1.e-3,
                                k=0.15,
                                gamma_scaler=1.5,
-                               n_stop=2)
+                               n_stop=2,
+                               kopt=True)
     assert res_no_kopt["error"] >= res_with_kopt["error"]

--- a/procrustes/test/test_softassign.py
+++ b/procrustes/test/test_softassign.py
@@ -89,10 +89,7 @@ def test_softassign_4by4_translate_scale():
     perm = np.array([[1., 0., 0.], [0., 0., 1.], [0., 1., 0.]])
     array_b = np.dot(perm.T, np.dot((14.7 * array_a + 3.14), perm))
     # Check
-    res = softassign(array_a, array_b,
-                     translate=True, scale=True,
-                     unpad_row=False,
-                     unpad_col=False)
+    res = softassign(array_a, array_b, translate=True, scale=True, unpad_col=False, unpad_row=False)
     assert_almost_equal(res["t"], perm, decimal=6)
     assert_almost_equal(res["error"], 0, decimal=6)
 
@@ -194,6 +191,22 @@ def test_softassign_invalid_beta_r():
     array_b = np.dot(perm.T, np.dot(array_a, perm))
     # Check
     assert_raises(ValueError, softassign, array_a, array_b, beta_r=0.5)
+
+
+def test_softassign_wrong_shapes():
+    r"""Test softassign with wrong shapes for the a, b input matrices."""
+    array_a = np.ones((10, 5))
+    array_b = np.ones((10, 10))
+    # Test A and B are not square matrices.
+    assert_raises(ValueError, softassign, array_a, array_b, pad=False)
+    # Test B is not square matrices.
+    array_a = np.ones((10, 10))
+    array_b = np.ones((10, 5))
+    assert_raises(ValueError, softassign, array_a, array_b, pad=False)
+    # Test A, B are square but with different shape.
+    array_a = np.ones((10, 10))
+    array_b = np.ones((20, 20))
+    assert_raises(ValueError, softassign, array_a, array_b, pad=False)
 
 
 def test_softassign_4by4_beta_0():


### PR DESCRIPTION
This pull-request updates the API of the soft-assign.

- Change `remove_zero_row` to `unpad_row` and `remove_zero_col` to `unpad_col`.
- One of the raise errors in othogonal.py was using `remove_zero_row` in its error message.
- Changed `array_a` to `a` and similarly for b matrix, made it more specific that a, b are (N,N) matrices.
- Raise error if shapes of a, b aren't square after padding/removing zero cols/rows. 
- Raise error if shapes of a and b are not the same.
- Added tests for these new raise error statements
- Change the order of function parameters to be the generic first (a, b, pad, unpad_row) then algorithm specifics.
- Changed a previous test to increase coverage to 100.