### PR TITLE
Fix missing dependencies for protein alignment

### DIFF
--- a/doc/notebooks/Chemical_Structure_Alignment.ipynb
+++ b/doc/notebooks/Chemical_Structure_Alignment.ipynb
@@ -26,6 +26,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# https://jakevdp.github.io/blog/2017/12/05/installing-python-packages-from-jupyter/\n",
+    "import sys\n",
+    "\n",
+    "# install iodata\n",
+    "!{sys.executable} -m pip install qc-iodata\n",
+    "# install matplotlib\n",
+    "!{sys.executable} -m pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
The original notebook has a problem of accessing the dependencies in the Binder server. Now it's fixed.