### PR TITLE
Fix buffer overflow vulnerability in NumPy 1.9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Dependencies
 The following dependencies are required to run Procrustes properly,
 
 * Python >= 3.6: http://www.python.org/
-* NumPy >= 1.18.5: http://www.numpy.org/
+* NumPy >= 1.21.5: http://www.numpy.org/
 * SciPy >= 1.5.0: http://www.scipy.org/
 * PyTest >= 5.3.4: https://docs.pytest.org/
 * PyTest-Cov >= 2.8.0: https://pypi.org/project/pytest-cov/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.18.5, <=1.20
+numpy>=1.21.5
 scipy>=1.5.0
 pytest>=5.4.3
 sphinx>=2.3.0


### PR DESCRIPTION
This problem is detailed in https://github.com/theochem/procrustes/security/dependabot/1. Now we set `numpy>=1.21.5`