### PR TITLE
Fix input file download and `nbsphinx` rendering

### DIFF
--- a/doc/notebooks/Chemical_Structure_Alignment.ipynb
+++ b/doc/notebooks/Chemical_Structure_Alignment.ipynb
@@ -31,7 +31,7 @@
     "#### Download IOData & Matplotlib Libraries & Example Files\n",
     "\n",
     "- Install [IOData library](https://github.com/theochem/iodata) and Matplotlib, if there are not available on your system; this is required on Binder.\n",
-    "- Download [*2hhb.pdb*](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chemical_strcuture_alignment/2hhb.pdb?raw=true?) file used in the example below which is stored in [Procrustes GitHub repository example files](https://github.com/theochem/procrustes/tree/master/doc/notebooks/notebook_data/chemical_strcuture_alignment)."
+    "- Download [2hhb.pdb](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chemical_strcuture_alignment/2hhb.pdb?raw=true?) file used in the example below which is stored in [Procrustes GitHub repository example files](https://github.com/theochem/procrustes/tree/master/doc/notebooks/notebook_data/chemical_strcuture_alignment)."
    ]
   },
   {

--- a/doc/notebooks/Chemical_Structure_Alignment.ipynb
+++ b/doc/notebooks/Chemical_Structure_Alignment.ipynb
@@ -31,7 +31,7 @@
     "#### Download IOData & Matplotlib Libraries & Example Files\n",
     "\n",
     "- Install [IOData library](https://github.com/theochem/iodata) and Matplotlib, if there are not available on your system; this is required on Binder.\n",
-    "- Download [`2hhb.pdb`](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chemical_strcuture_alignment/2hhb.pdb?raw=true?) file used in the example below which is stored in [Procrustes GitHub repository example files](https://github.com/theochem/procrustes/tree/master/doc/notebooks/notebook_data/chemical_strcuture_alignment); this is required on Binder."
+    "- Download [*2hhb.pdb*](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chemical_strcuture_alignment/2hhb.pdb?raw=true?) file used in the example below which is stored in [Procrustes GitHub repository example files](https://github.com/theochem/procrustes/tree/master/doc/notebooks/notebook_data/chemical_strcuture_alignment)."
    ]
   },
   {
@@ -56,13 +56,17 @@
    "outputs": [],
    "source": [
     "# If needed, download the example files\n",
+    "import os\n",
+    "from urllib.request import urlretrieve\n",
     "\n",
-    "import urllib.request\n",
+    "fpath = \"notebook_data/chemical_strcuture_alignment/\"\n",
+    "if not os.path.exists(fpath):\n",
+    "    os.makedirs(fpath, exist_ok=True)\n",
     "\n",
-    "urllib.request.urlretrieve(\n",
-    "    \"https://raw.githubusercontent.com/theochem/procrustes/master/doc/notebooks/notebook_data/chemical_strcuture_alignment/2hhb.pdb\", \n",
-    "    \"2hhb.pdb\"\n",
-    ")"
+    "urlretrieve(\n",
+    "    \"https://raw.githubusercontent.com/theochem/procrustes/master/doc/notebooks/notebook_data/chemical_strcuture_alignment/2hhb.pdb\",\n",
+    "    os.path.join(fpath, \"2hhb.pdb\")\n",
+    "    )"
    ]
   },
   {
@@ -74,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -88,15 +92,15 @@
    ],
    "source": [
     "# chemical structure alignment with orthogonal Procrustes\n",
+    "from pathlib import Path\n",
     "\n",
-    "import numpy as np\n",
-    "    \n",
+    "import numpy as np    \n",
     "from iodata import load_one\n",
     "from iodata.utils import angstrom\n",
     "from procrustes import rotational\n",
     "\n",
     "# load PDB\n",
-    "pdb = load_one(\"2hhb.pdb\")\n",
+    "pdb = load_one(Path(\"notebook_data/chemical_strcuture_alignment/2hhb.pdb\"))\n",
     "\n",
     "# get coordinates of C_alpha atoms in chains A & C (in angstrom)\n",
     "chainid = pdb.extra['chainids']\n",
@@ -130,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -216,7 +220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/notebooks/Chirality_Check.ipynb
+++ b/doc/notebooks/Chirality_Check.ipynb
@@ -40,7 +40,7 @@
     "#### Download IOData & Matplotlib Libraries & Example Files\n",
     "\n",
     "- Install [IOData Package](https://github.com/theochem/iodata) and Matplotlib, if there are not available on your system; this is required on Binder.\n",
-    "- Download [`enantiomer1.xyz`](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chirality_checking/enantiomer1.xyz?raw=true?) and [`enantiomer2.xyz`](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chirality_checking/enantiomer2.xyz?raw=true?) files used in the example below which are stored in [Procrustes GitHub repository example files](https://github.com/theochem/procrustes/tree/master/doc/notebooks/notebook_data/chirality_checking); this is required on Binder."
+    "- Download [*enantiomer1.xyz*](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chirality_checking/enantiomer1.xyz?raw=true?) and [*enantiomer2.xyz*](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chirality_checking/enantiomer2.xyz?raw=true?) files used in the example below which are stored in [Procrustes GitHub repository example files](https://github.com/theochem/procrustes/tree/master/doc/notebooks/notebook_data/chirality_checking)."
    ]
   },
   {
@@ -65,17 +65,21 @@
    "outputs": [],
    "source": [
     "# If needed, download the example files\n",
-    "\n",
+    "import os\n",
     "import urllib.request\n",
+    "\n",
+    "fpath = \"notebook_data/chirality_checking/\"\n",
+    "if not os.path.exists(fpath):\n",
+    "    os.makedirs(fpath, exist_ok=True)\n",
     "\n",
     "urllib.request.urlretrieve(\n",
     "    \"https://raw.githubusercontent.com/theochem/procrustes/master/doc/notebooks/notebook_data/chirality_checking/enantiomer1.xyz\", \n",
-    "    \"enantiomer1.xyz\"\n",
+    "    os.path.join(fpath, \"enantiomer1.xyz\")\n",
     ")\n",
     "\n",
     "urllib.request.urlretrieve(\n",
     "    \"https://raw.githubusercontent.com/theochem/procrustes/master/doc/notebooks/notebook_data/chirality_checking/enantiomer2.xyz\", \n",
-    "    \"enantiomer2.xyz\"\n",
+    "    os.path.join(fpath, \"enantiomer2.xyz\")\n",
     ")"
    ]
   },
@@ -102,15 +106,15 @@
    ],
    "source": [
     "# chirality check with rotational and orthogonal Procrustes\n",
+    "from pathlib import Path\n",
     "\n",
     "import numpy as np\n",
-    "\n",
     "from iodata import load_one\n",
     "from procrustes import orthogonal, rotational\n",
     "\n",
     "# load CHClFBr enantiomers' coordinates from XYZ files\n",
-    "a = load_one(\"enantiomer1.xyz\").atcoords\n",
-    "b = load_one(\"enantiomer2.xyz\").atcoords\n",
+    "a = load_one(Path(\"notebook_data/chirality_checking/enantiomer1.xyz\")).atcoords\n",
+    "b = load_one(Path(\"notebook_data/chirality_checking/enantiomer2.xyz\")).atcoords\n",
     "\n",
     "# rotational Procrustes on a & b coordinates\n",
     "result_rot = rotational(a, b, translate=True, scale=False)\n",
@@ -218,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/notebooks/Chirality_Check.ipynb
+++ b/doc/notebooks/Chirality_Check.ipynb
@@ -40,7 +40,7 @@
     "#### Download IOData & Matplotlib Libraries & Example Files\n",
     "\n",
     "- Install [IOData Package](https://github.com/theochem/iodata) and Matplotlib, if there are not available on your system; this is required on Binder.\n",
-    "- Download [*enantiomer1.xyz*](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chirality_checking/enantiomer1.xyz?raw=true?) and [*enantiomer2.xyz*](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chirality_checking/enantiomer2.xyz?raw=true?) files used in the example below which are stored in [Procrustes GitHub repository example files](https://github.com/theochem/procrustes/tree/master/doc/notebooks/notebook_data/chirality_checking)."
+    "- Download [enantiomer1.xyz](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chirality_checking/enantiomer1.xyz?raw=true?) and [enantiomer2.xyz](https://github.com/theochem/procrustes/blob/master/doc/notebooks/notebook_data/chirality_checking/enantiomer2.xyz?raw=true?) files used in the example below which are stored in [Procrustes GitHub repository example files](https://github.com/theochem/procrustes/tree/master/doc/notebooks/notebook_data/chirality_checking)."
    ]
   },
   {


### PR DESCRIPTION
The original block downloads the input files with the same directory
of the Jupyter files, but this is redundant if one clones the repo.
Moreover, if one runs the Procrustes analysis blocks without running
the download block, it will result to errors as the file path it points
to is not right. Now everything is fixed and running in Binder does not
require people to download the input files.