### PR TITLE
Add `CITATION.cff` to enable automatic citation style generation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,35 +1,58 @@
 cff-version: "1.2.0"
 message: "If you use this software, please cite it using this metadata. Thank you."
-
-references:
+authors:
+  - family-names: Meng
+    given-names: Fanwang
+    orcid: "https://orcid.org/0000-0003-2886-7012"
+  - family-names: Richer
+    given-names: Michael
+  - family-names: Tehrani
+    given-names: Alireza
+    orcid: "https://orcid.org/0000-0003-1308-8614"
+  - family-names: La
+    given-names: Jonathan
+  - family-names: Kim
+    given-names: "Taewon David"
+    orcid: "https://orcid.org/0000-0001-8670-0531"
+  - family-names: Ayers
+    given-names: "Paul W."
+    orcid: "https://orcid.org/0000-0003-2605-3883"
+  - family-names: Farnaz
+    given-names: "Heidar-Zadeh"
+    orcid: "https://orcid.org/0000-0002-2069-050X"
+title: "Procrustes: A python library to find transformations that maximize the similarity between matrices"
+version: 1.0.0
+date-released: 2022-02-25
+url: "https://github.com/theochem/procrustes"
+preferred-citation:
+  type: article
   authors:
-    - type: article
-    authors:
-      - family-names: Meng
-        given-names: Fanwang
-        orcid: "https://orcid.org/0000-0003-2886-7012"
-      - family-names: Richer
-        given-names: Michael
-      - family-names: Tehrani
-        given-names: Alireza
-        orcid: "https://orcid.org/0000-0003-1308-8614"
-      - family-names: La
-        given-names: Jonathan
-      - family-names: Kim
-        given-names: "Taewon David"
-        orcid: "https://orcid.org/0000-0001-8670-0531"
-      - family-names: Ayers
-        given-names: "Paul W."
-        orcid: "https://orcid.org/0000-0003-2605-3883"
-      - family-names: Farnaz
-        given-names: "Heidar-Zadeh"
-        orcid: "https://orcid.org/0000-0002-2069-050X"
-  title: "Procrustes: A python library to find transformations that maximize the similarity between matrices"
-  journal: "Computer Physics Communications"
-  volume: "276"
-  pages: "108334"
-  isbn: 0010-4655
-  year: 2022
-  doi: "10.1016/j.cpc.2022.108334"
-  date-released: "2022-03-10"
-  url: "https://doi.org/10.1016/j.cpc.2022.108334"
+    - family-names: Meng
+      given-names: Fanwang
+      orcid: "https://orcid.org/0000-0003-2886-7012"
+    - family-names: Richer
+      given-names: Michael
+    - family-names: Tehrani
+      given-names: Alireza
+      orcid: "https://orcid.org/0000-0003-1308-8614"
+    - family-names: La
+      given-names: Jonathan
+    - family-names: Kim
+      given-names: "Taewon David"
+      orcid: "https://orcid.org/0000-0001-8670-0531"
+    - family-names: Ayers
+      given-names: "Paul W."
+      orcid: "https://orcid.org/0000-0003-2605-3883"
+    - family-names: Farnaz
+      given-names: "Heidar-Zadeh"
+      orcid: "https://orcid.org/0000-0002-2069-050X"
+    doi: "10.1016/j.cpc.2022.108334"
+    journal: "Computer Physics Communications"
+    title: "Procrustes: A python library to find transformations that maximize the similarity between matrices"
+    volume: "276"
+    start: "108334"
+    end: "108334"
+    isbn: 0010-4655
+    year: 2022
+    date-released: "2022-03-10"
+    url: "https://doi.org/10.1016/j.cpc.2022.108334"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,32 @@
-cff-version: "1.2.0"
-message: "If you use this software, please cite it using this metadata. Thank you."
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
 authors:
+- family-names: Meng
+  given-names: Fanwang
+  orcid: "https://orcid.org/0000-0003-2886-7012"
+- family-names: Richer
+  given-names: Michael
+- family-names: Tehrani
+  given-names: Alireza
+  orcid: "https://orcid.org/0000-0003-1308-8614"
+- family-names: La
+  given-names: Jonathan
+- family-names: Kim
+  given-names: "Taewon David"
+  orcid: "https://orcid.org/0000-0001-8670-0531"
+- family-names: Ayers
+  given-names: "Paul W."
+  orcid: "https://orcid.org/0000-0003-2605-3883"
+- family-names: Farnaz
+  given-names: "Heidar-Zadeh"
+  orcid: "https://orcid.org/0000-0002-2069-050X"
+title: "Procrustes: A python library to find transformations that maximize the similarity between matrices"
+version: 1.0.0
+date-released: 2022-02-25
+url: "https://github.com/theochem/procrustes"
+preferred-citation:
+  type: article
+  authors:
   - family-names: Meng
     given-names: Fanwang
     orcid: "https://orcid.org/0000-0003-2886-7012"
@@ -20,39 +46,12 @@ authors:
   - family-names: Farnaz
     given-names: "Heidar-Zadeh"
     orcid: "https://orcid.org/0000-0002-2069-050X"
-title: "Procrustes: A python library to find transformations that maximize the similarity between matrices"
-version: 1.0.0
-date-released: 2022-02-25
-url: "https://github.com/theochem/procrustes"
-preferred-citation:
-  type: article
-  authors:
-    - family-names: Meng
-      given-names: Fanwang
-      orcid: "https://orcid.org/0000-0003-2886-7012"
-    - family-names: Richer
-      given-names: Michael
-    - family-names: Tehrani
-      given-names: Alireza
-      orcid: "https://orcid.org/0000-0003-1308-8614"
-    - family-names: La
-      given-names: Jonathan
-    - family-names: Kim
-      given-names: "Taewon David"
-      orcid: "https://orcid.org/0000-0001-8670-0531"
-    - family-names: Ayers
-      given-names: "Paul W."
-      orcid: "https://orcid.org/0000-0003-2605-3883"
-    - family-names: Farnaz
-      given-names: "Heidar-Zadeh"
-      orcid: "https://orcid.org/0000-0002-2069-050X"
-    doi: "10.1016/j.cpc.2022.108334"
-    journal: "Computer Physics Communications"
-    title: "Procrustes: A python library to find transformations that maximize the similarity between matrices"
-    volume: "276"
-    start: "108334"
-    end: "108334"
-    isbn: 0010-4655
-    year: 2022
-    date-released: "2022-03-10"
-    url: "https://doi.org/10.1016/j.cpc.2022.108334"
+  doi: "10.1016/j.cpc.2022.108334"
+  journal: "Computer Physics Communications"
+  start: 1 # First page number
+  end: 37 # Last page number
+  title: "Procrustes: A python library to find transformations that maximize the similarity between matrices"
+  issue: 108334
+  volume: 276
+  year: 2022
+  date-released: "2022-03-10"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+cff-version: "1.2.0"
+message: "If you use this software, please cite it using this metadata. Thank you."
+
+references:
+  authors:
+    - type: article
+    authors:
+      - family-names: Meng
+        given-names: Fanwang
+        orcid: "https://orcid.org/0000-0003-2886-7012"
+      - family-names: Richer
+        given-names: Michael
+      - family-names: Tehrani
+        given-names: Alireza
+        orcid: "https://orcid.org/0000-0003-1308-8614"
+      - family-names: La
+        given-names: Jonathan
+      - family-names: Kim
+        given-names: "Taewon David"
+        orcid: "https://orcid.org/0000-0001-8670-0531"
+      - family-names: Ayers
+        given-names: "Paul W."
+        orcid: "https://orcid.org/0000-0003-2605-3883"
+      - family-names: Farnaz
+        given-names: "Heidar-Zadeh"
+        orcid: "https://orcid.org/0000-0002-2069-050X"
+  title: "Procrustes: A python library to find transformations that maximize the similarity between matrices"
+  journal: "Computer Physics Communications"
+  volume: "276"
+  pages: "108334"
+  isbn: 0010-4655
+  year: 2022
+  doi: "10.1016/j.cpc.2022.108334"
+  date-released: "2022-03-10"
+  url: "https://doi.org/10.1016/j.cpc.2022.108334"

--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ Please use the following citation in any publication using Procrustes library:
 ```md
 @article{Meng2022procrustes,
 title = {Procrustes: A python library to find transformations that maximize the similarity between matrices},
+author = {Fanwang Meng and Michael Richer and Alireza Tehrani and Jonathan La and Taewon David Kim and Paul W. Ayers and Farnaz Heidar-Zadeh},
 journal = {Computer Physics Communications},
 volume = {276},
-pages = {108334},
+number = {108334},
+pages = {1--37},
 year = {2022},
 issn = {0010-4655},
 doi = {https://doi.org/10.1016/j.cpc.2022.108334},
 url = {https://www.sciencedirect.com/science/article/pii/S0010465522000522},
-author = {Fanwang Meng and Michael Richer and Alireza Tehrani and Jonathan La and Taewon David Kim and Paul W. Ayers and Farnaz Heidar-Zadeh},
 keywords = {Procrustes analysis, Orthogonal, Symmetric, Rotational, Permutation, Softassign},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ as similar as possible to a target matrix. For more information, visit
 Citation
 --------
 
-Please use the following citation in any publication using Procrustes library:
+Please use [the following citation](https://doi.org/10.1016/j.cpc.2022.108334)
+in any publication using Procrustes library:
 
 ```md
 @article{Meng2022procrustes,

--- a/README.md
+++ b/README.md
@@ -20,10 +20,20 @@ Citation
 
 Please use the following citation in any publication using Procrustes library:
 
-> **"Procrustes: A Python Library to Find Transformations that Maximize the Similarity Between
-> Matrices."**, F. Meng, M. Richer, A. Tehrani, J. La, T. D. Kim, P. W. Ayers, F. Heidar-Zadeh,
-> [JOURNAL XXX]().
-
+```md
+@article{Meng2022procrustes,
+title = {Procrustes: A python library to find transformations that maximize the similarity between matrices},
+journal = {Computer Physics Communications},
+volume = {276},
+pages = {108334},
+year = {2022},
+issn = {0010-4655},
+doi = {https://doi.org/10.1016/j.cpc.2022.108334},
+url = {https://www.sciencedirect.com/science/article/pii/S0010465522000522},
+author = {Fanwang Meng and Michael Richer and Alireza Tehrani and Jonathan La and Taewon David Kim and Paul W. Ayers and Farnaz Heidar-Zadeh},
+keywords = {Procrustes analysis, Orthogonal, Symmetric, Rotational, Permutation, Softassign},
+}
+```
 
 Dependencies
 ------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,7 +36,7 @@ Please use the following citation in any publication using Procrustes library:
 
     **"Procrustes: A Python Library to Find Transformations that Maximize the Similarity Between
     Matrices"**, F. Meng, M. Richer, A. Tehrani, J. La, T. D. Kim, P. W. Ayers, F. Heidar-Zadeh,
-    `JOURNAL 2021; ISSUE PAGE NUMBER <URL>`__.
+    `JComputer Physics Communications, 276(108334), 2022. <https://doi.org/10.1016/j.cpc.2022.108334>`__.
 
 The Procrustes source code is hosted on `GitHub <https://github.com/theochem/procrustes>`_ and is
 released under the

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,7 +36,7 @@ Please use the following citation in any publication using Procrustes library:
 
     **"Procrustes: A Python Library to Find Transformations that Maximize the Similarity Between
     Matrices"**, F. Meng, M. Richer, A. Tehrani, J. La, T. D. Kim, P. W. Ayers, F. Heidar-Zadeh,
-    `JComputer Physics Communications, 276(108334), 2022. <https://doi.org/10.1016/j.cpc.2022.108334>`__.
+    `Computer Physics Communications, 276(108334), 2022. <https://doi.org/10.1016/j.cpc.2022.108334>`__.
 
 The Procrustes source code is hosted on `GitHub <https://github.com/theochem/procrustes>`_ and is
 released under the


### PR DESCRIPTION
The `CITATION.cff` was generated based on https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files.