### PR TITLE
Remove deprecated `pinv2` function in `scipy`

### DIFF
--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 import numpy as np
 from procrustes.utils import compute_error, ProcrustesResult, setup_input_arrays
-from scipy.linalg import pinv, pinv2
+from scipy.linalg import pinv
 
 
 __all__ = [
@@ -44,7 +44,6 @@ def generic(
     unpad_row: bool = False,
     check_finite: bool = True,
     weight: Optional[np.ndarray] = None,
-    use_svd: bool = False,
 ) -> ProcrustesResult:
     r"""Perform generic one-sided Procrustes.
 
@@ -90,12 +89,6 @@ def generic(
         The 1D-array representing the weights of each row of :math:`\mathbf{A}`. This defines the
         elements of the diagonal matrix :math:`\mathbf{W}` that is multiplied by :math:`\mathbf{A}`
         matrix, i.e., :math:`\mathbf{A} \rightarrow \mathbf{WA}`.
-    use_svd : bool, optional
-        If True, the (Moore-Penrose) pseudo-inverse is computed by singular-value decomposition
-        (SVD) including all 'large' singular values (using `scipy.linalg.pinv2`).
-        If False, the the (Moore-Penrose) pseudo-inverse is computed by least-squares solver
-        (using `scipy.linalg.pinv`). The least-squares implementation is less efficient, but more
-        robust, than the SVD implementation.
 
     Returns
     -------
@@ -114,9 +107,6 @@ def generic(
     unknowns).
 
     """
-    if not isinstance(use_svd, bool):
-        raise TypeError(f"The use_svd parameter {type(use_svd)} should be type bool.")
-
     # check inputs
     new_a, new_b = setup_input_arrays(
         a,
@@ -130,12 +120,7 @@ def generic(
         weight,
     )
     # compute the generic solution
-    if use_svd:
-        # Use the singular value decomposition, much faster but less robust.
-        a_inv = pinv2(np.dot(new_a.T, new_a))
-    else:
-        # Uses the least-squared method.
-        a_inv = pinv(np.dot(new_a.T, new_a))
+    a_inv = pinv(np.dot(new_a.T, new_a))
 
     array_x = np.linalg.multi_dot([a_inv, new_a.T, new_b])
     # compute one-sided error

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -23,7 +23,7 @@
 """Test procrustes.generic module."""
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_raises
+from numpy.testing import assert_almost_equal
 from procrustes.generic import generic
 import pytest
 

--- a/procrustes/test/test_generic.py
+++ b/procrustes/test/test_generic.py
@@ -55,15 +55,12 @@ def test_generic_square_lapack_driver_and_assertion_error(m):
     array_x = np.random.uniform(-2.0, 2.0, (m, m))
     array_b = np.dot(array_a, array_x)
     # compute procrustes transformation
-    res = generic(array_a, array_b, translate=False, scale=False, use_svd=True)
+    res = generic(array_a, array_b, translate=False, scale=False)
     # check error & arrays
     assert_almost_equal(res.error, 0.0, decimal=6)
     assert_almost_equal(res.t, array_x, decimal=6)
     assert_almost_equal(res.new_a, array_a, decimal=6)
     assert_almost_equal(res.new_b, array_b, decimal=6)
-
-    # Check assertion error
-    assert_raises(TypeError, generic, array_a, array_b, use_svd="not bool")
 
 
 @pytest.mark.parametrize("m, n", np.random.randint(2, 100, (25, 2)))


### PR DESCRIPTION
More details is listed in https://github.com/scipy/scipy/issues/8861#issuecomment-1030803006

This PR fixes #174.