### PR TITLE
Add `codecov` coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Procrustes
 [![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/)
 [![GitHub Actions CI Tox Status](https://github.com/theochem/procrustes/actions/workflows/ci_tox.yml/badge.svg?branch=master)](https://github.com/theochem/procrustes/actions/workflows/ci_tox.yml)
 [![Documentation Status](https://readthedocs.org/projects/procrustes/badge/?version=latest)](https://procrustes.readthedocs.io/en/latest/?badge=latest)
+[![codecov](https://codecov.io/gh/theochem/procrustes/branch/master/graph/badge.svg?token=3L96J5QQOT)](https://codecov.io/gh/theochem/procrustes)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/theochem/procrustes/master?filepath=doc%2Fnotebooks%2F)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/theochem/procrustes.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/theochem/procrustes/context:python)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,6 +23,8 @@ coverage:
 
   # ignore statistics for the testing folders
   ignore:
+    - setup.py
+    - updateheaders.py
     - .*/test/.*
     - .*/examples/.*
     - .*/__int__.py


### PR DESCRIPTION
This PR fixes the original incorrect coverage report by excluding some PY files that are not algorithm implementation. Fix the file name of codecov configuration where the file with dot cannot be recognized by the web server. 