### PR TITLE
Clarify quickstart notebook re translation/scaling

### DIFF
--- a/doc/notebooks/Quick_Start.ipynb
+++ b/doc/notebooks/Quick_Start.ipynb
@@ -161,7 +161,7 @@
    "id": "6163449e",
    "metadata": {},
    "source": [
-    "### Accessing Scaling, Translation Related Information"
+    "### Accessing Scaling- and Translation-Related Information"
    ]
   },
   {
@@ -190,7 +190,7 @@
     "# accessing the scaling factor when preparing two input matrices\n",
     "from procrustes.utils import _scale_array\n",
     "\n",
-    "# array_a is scaled to match array_b's norm and the norm of $a$ will be equal norm of $b$\n",
+    "# array_a is scaled to match array_b's norm; after scaling the norm of $a$ equals the norm of $b$\n",
     "scaled_a, scaling_factor = _scale_array(a, b)\n",
     "# print(f\"The scaled matrix $a$ is {scaled_a}.\")\n",
     "print(f\"The scaling factor is {scaling_factor}.\")"
@@ -201,7 +201,7 @@
    "id": "fc78f6d5",
    "metadata": {},
    "source": [
-    "The user may also want to get the translation matrix or the translated matrix. This can be achieved by using `_translate_array` function in `utils` module."
+    "The user may also want to get the translation matrix or the translated matrix. This can be achieved by using `_translate_array` function in the `utils` module."
    ]
   },
   {
@@ -223,8 +223,8 @@
     "# accessing the translation matrix\n",
     "from procrustes.utils import _translate_array\n",
     "\n",
-    "# rray_a is translated to centroid of array_b\n",
-    "# the centroid of translated $a$ will centroid with the centroid $b$\n",
+    "# array_a is translated to centroid of array_b\n",
+    "# after translation, the centroid of $a$ will match the centroid of $b$\n",
     "trans_array_a, centroid = _translate_array(a, b)\n",
     "# print(f\"The translated array $a$ is {trans_array_a}.\")\n",
     "print(f\"The centroid is {centroid}.\")"


### PR DESCRIPTION
Adjusted wording and fixed a couple typos related to the translation/scaling clarification made by @FanwangM . 

With these pull requests, it should be easy for a user to print out translation/scaling factors as needed, as well as recover the translated/scaled versions of the array $a$.