### PR TITLE
Add case when matrix is ill-conditioned for generic procrustes

### DIFF
--- a/procrustes/generic.py
+++ b/procrustes/generic.py
@@ -120,7 +120,15 @@ def generic(
         weight,
     )
     # compute the generic solution
-    a_inv = pinv(np.dot(new_a.T, new_a))
+    try:
+        a_inv = pinv(np.dot(new_a.T, new_a))
+    # add little bit of random noise when the matrix is ill conditioned
+    except np.linalg.LinAlgError:
+        # conver new_a to float if it is not
+        new_a = new_a.astype(float)
+        new_a += 2e-14 * np.random.random_sample((new_a.shape[0], new_a.shape[1])) - 1e-14
+        a_inv = pinv(np.dot(new_a.T, new_a))
+    # a_inv = pinv(np.dot(new_a.T, new_a))
 
     array_x = np.linalg.multi_dot([a_inv, new_a.T, new_b])
     # compute one-sided error


### PR DESCRIPTION
This is fixed by adding a small random noise, as discussed in https://github.com/theochem/procrustes/issues/197. 

The `pinv` function is implemented in
https://github.com/scipy/scipy/blob/4bd5e943cbf30efde4becea48c388faafa14e9e4/scipy/linalg/_basic.py#L1447, which replies on https://github.com/scipy/scipy/blob/4bd5e943cbf30efde4becea48c388faafa14e9e4/scipy/linalg/_decomp_svd.py#L13-L169. The implementation of `pinv` only checks explicitly if the tolerance values are valid. 