### PR TITLE
Add too-many-positional-arguments to ignore list for `pylint`

### DIFF
--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -63,7 +63,7 @@ jobs:
         python -m pytest -c pyproject.toml --cov-config=.coveragerc --cov-report=xml --color=yes procrustes
 
     - name: CodeCov
-      uses: codecov/codecov-action@v4.5.0
+      uses: codecov/codecov-action@v4.6.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         # Temp fix for https://github.com/codecov/codecov-action/issues/1487

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,6 +284,7 @@ disable = [
     "no-else-return",
     "no-member",
     "too-many-branches",
+    "too-many-positional-arguments",
 ]
 
 [tool.pylint."MASTER"]

--- a/tox.ini
+++ b/tox.ini
@@ -233,6 +233,8 @@ disable=
     # Used when a name doesn't doesn't fit the naming convention associated to its type
     # (constant, variable, class…).
     C0103,
+    # Used when too many positional arguments are given in a function call.
+    R0917,
 
 [SIMILARITIES]
 min-similarity-lines=5


### PR DESCRIPTION
This fixes the failing test.