### PR TITLE
Fix generalized procrustes algorithm

### DIFF
--- a/procrustes/generalized.py
+++ b/procrustes/generalized.py
@@ -106,6 +106,7 @@ def generalized(
         new_distance_gpa = np.square(ref - new_ref).sum()
         if distance_gpa != np.inf and np.abs(new_distance_gpa - distance_gpa) < tol:
             break
+        ref = new_ref
         distance_gpa = new_distance_gpa
     return array_aligned, new_distance_gpa
 


### PR DESCRIPTION
The generalized procrustes implementation was never updating the reference shape -- in effect, this means it would always run just one iteration of the algorithm and then return because the change in ref would be zero. This PR adds the missing line to update the reference shape.

(Might also be a good idea to add a test which catches this in the future since the existing ones didn't -- though that could always be added later.)